### PR TITLE
ユーザー登録機能とSpring Securityの設定を追加

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
 /gradlew text eol=lf
 *.bat text eol=crlf
 *.jar binary
+
+# すべてのテキストファイルをLFに統一
+* text=auto eol=lf
+

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -35,6 +37,7 @@ dependencies {
 	testImplementation 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/ozeken/expensecalendar/config/PasswordConfig.java
+++ b/src/main/java/com/ozeken/expensecalendar/config/PasswordConfig.java
@@ -1,0 +1,17 @@
+package com.ozeken.expensecalendar.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/** パスワードエンコーダーの設定 */
+@Configuration
+public class PasswordConfig {
+	
+	/** BCrypt を使ったパスワードエンコーダーを提供 */
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/ozeken/expensecalendar/config/SecurityConfig.java
+++ b/src/main/java/com/ozeken/expensecalendar/config/SecurityConfig.java
@@ -1,0 +1,55 @@
+package com.ozeken.expensecalendar.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+	
+	//必要ならばDIして使用する
+	private final UserDetailsService userDetailsService;
+	private final PasswordEncoder passwordEncoder;
+		
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .authorizeHttpRequests(auth -> auth
+            		// "/"、"/login"、"/register"、"/css/**"は認証なしでアクセス可能
+                .requestMatchers("/", "/login", "/register", "/css/**").permitAll()
+                //その他のリクエストは認証が必要
+                .anyRequest().authenticated()
+            )
+            .formLogin(form -> form
+                .loginPage("/login")
+                //すべてのユーザーに"/expenses"にリダイレクト
+                .defaultSuccessUrl("/expenses", true)
+                //ログイン失敗時のリダイレクト先
+                .failureUrl("/login?error=true")
+                .permitAll()
+            )
+            .rememberMe(remember -> remember
+            	    .key("uniqueAndSecret")
+            	    // remember-meトークンの有効期限を30日間に設定
+            	    .tokenValiditySeconds(60 * 60 * 24 * 30)
+            	    .rememberMeCookieName("remember-me")
+            	    .rememberMeParameter("remember-me")
+			)
+    		//ログアウト後、クッキー、トークンを削除して"/"にリダイレクト
+            .logout(logout -> logout
+                .logoutSuccessUrl("/")
+                .deleteCookies("JSESSIONID","remember-me")
+                .permitAll());
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/ozeken/expensecalendar/config/SecurityConfig.java
+++ b/src/main/java/com/ozeken/expensecalendar/config/SecurityConfig.java
@@ -5,7 +5,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 import lombok.RequiredArgsConstructor;
@@ -15,9 +14,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SecurityConfig {
 	
-	//必要ならばDIして使用する
+	// DI対象が存在すれば、DIして保存する
 	private final UserDetailsService userDetailsService;
-	private final PasswordEncoder passwordEncoder;
 		
 
     @Bean
@@ -26,9 +24,13 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
             		// "/"、"/login"、"/register"、"/css/**"は認証なしでアクセス可能
                 .requestMatchers("/", "/login", "/register", "/css/**").permitAll()
+                .requestMatchers("/admin/**").hasRole("ADMIN")
                 //その他のリクエストは認証が必要
                 .anyRequest().authenticated()
             )
+            
+            .userDetailsService(userDetailsService)
+            
             .formLogin(form -> form
                 .loginPage("/login")
                 //すべてのユーザーに"/expenses"にリダイレクト

--- a/src/main/java/com/ozeken/expensecalendar/controller/LoginController.java
+++ b/src/main/java/com/ozeken/expensecalendar/controller/LoginController.java
@@ -1,0 +1,15 @@
+package com.ozeken.expensecalendar.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/login")
+public class LoginController {
+
+	@GetMapping
+	public String showLogin() {
+		return "login";
+	}
+}

--- a/src/main/java/com/ozeken/expensecalendar/controller/LoginController.java
+++ b/src/main/java/com/ozeken/expensecalendar/controller/LoginController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequestMapping("/login")
 public class LoginController {
 
+	/** ログイン画面の表示 */
 	@GetMapping
 	public String showLogin() {
 		return "login";

--- a/src/main/java/com/ozeken/expensecalendar/controller/RegisterController.java
+++ b/src/main/java/com/ozeken/expensecalendar/controller/RegisterController.java
@@ -1,0 +1,51 @@
+package com.ozeken.expensecalendar.controller;
+
+import jakarta.validation.Valid;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.ozeken.expensecalendar.form.RegisterForm;
+import com.ozeken.expensecalendar.service.RegisterService;
+
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/register")
+public class RegisterController {
+
+	//DI
+    private final RegisterService registerService;
+
+    /** ユーザー登録画面の表示*/
+    @GetMapping
+    public String showRegisterForm(Model model) {
+        model.addAttribute("registerForm", new RegisterForm());
+        return "register";
+    }
+    
+    /** 登録処理*/
+    @PostMapping
+    public String register(@ModelAttribute("registerForm") @Valid RegisterForm form,
+                           BindingResult result,
+                           Model model) {
+
+        if (registerService.isDuplicateUsername(form.getUsername())) {
+            result.rejectValue("username", "duplicate", "このユーザー名はすでに使用されています。");
+        }
+
+        if (result.hasErrors()) {
+            model.addAttribute("registerForm", form);
+            return "register";
+        }
+
+        registerService.register(form);
+        return "redirect:/login";
+    }
+}

--- a/src/main/java/com/ozeken/expensecalendar/controller/ShowHomeController.java
+++ b/src/main/java/com/ozeken/expensecalendar/controller/ShowHomeController.java
@@ -1,0 +1,13 @@
+package com.ozeken.expensecalendar.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class ShowHomeController {
+
+    @GetMapping("/")
+    public String showHomePage() {
+        return "home";
+    }
+}

--- a/src/main/java/com/ozeken/expensecalendar/entity/AppUser.java
+++ b/src/main/java/com/ozeken/expensecalendar/entity/AppUser.java
@@ -1,0 +1,21 @@
+package com.ozeken.expensecalendar.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+import lombok.Data;
+
+@Data
+@Entity
+public class AppUser {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String username;
+    private String password;
+    private String role; // "USER" や "ADMIN"
+}

--- a/src/main/java/com/ozeken/expensecalendar/entity/AppUser.java
+++ b/src/main/java/com/ozeken/expensecalendar/entity/AppUser.java
@@ -15,6 +15,7 @@ public class AppUser {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    
     private String username;
     private String password;
     private String role; // "USER" や "ADMIN"

--- a/src/main/java/com/ozeken/expensecalendar/entity/LoginUser.java
+++ b/src/main/java/com/ozeken/expensecalendar/entity/LoginUser.java
@@ -1,0 +1,32 @@
+package com.ozeken.expensecalendar.entity;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+public class LoginUser extends User {
+
+	
+    private final AppUser appUser;
+
+    public LoginUser(AppUser appUser) {
+        super(
+            Objects.requireNonNull(appUser, "AppUser must not be null").getUsername(),
+            appUser.getPassword(),
+            getAuthorities(appUser)
+        );
+        this.appUser = appUser;
+    }
+
+    public AppUser getAppUser() {
+        return appUser;
+    }
+
+    private static Collection<? extends GrantedAuthority> getAuthorities(AppUser user) {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole()));
+    }
+}

--- a/src/main/java/com/ozeken/expensecalendar/entity/Role.java
+++ b/src/main/java/com/ozeken/expensecalendar/entity/Role.java
@@ -1,0 +1,6 @@
+package com.ozeken.expensecalendar.entity;
+
+public enum Role {
+	USER,
+	ADMIN;
+}

--- a/src/main/java/com/ozeken/expensecalendar/form/RegisterForm.java
+++ b/src/main/java/com/ozeken/expensecalendar/form/RegisterForm.java
@@ -1,0 +1,15 @@
+package com.ozeken.expensecalendar.form;
+
+import jakarta.validation.constraints.NotBlank;
+
+import lombok.Data;
+
+@Data
+public class RegisterForm {
+	
+    @NotBlank(message = "ユーザー名は必須です。")
+    private String username;
+
+    @NotBlank(message = "パスワードは必須です。")
+    private String password;
+}

--- a/src/main/java/com/ozeken/expensecalendar/helper/LoginHelper.java
+++ b/src/main/java/com/ozeken/expensecalendar/helper/LoginHelper.java
@@ -1,0 +1,41 @@
+package com.ozeken.expensecalendar.helper;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import com.ozeken.expensecalendar.entity.AppUser;
+import com.ozeken.expensecalendar.form.RegisterForm;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * LoginHelperクラス
+ */
+
+@Component
+@RequiredArgsConstructor
+public class LoginHelper {
+	
+	
+	//DI
+	private final PasswordEncoder passwordEncoder;
+	
+	
+	/**AppUserとRegisterFormの変換を行うメソッド*/
+	public RegisterForm convertToLoginForm(AppUser user) {
+		RegisterForm form = new RegisterForm();
+		form.setUsername(user.getUsername());
+		form.setPassword(user.getPassword());
+		return form;
+	}
+	
+	/**appUserをRegisterFormに変換を行うメソッド*/
+	public AppUser convertToAppUser(RegisterForm form) {
+		AppUser user = new AppUser();
+		user.setUsername(form.getUsername());
+		user.setPassword(passwordEncoder.encode(form.getPassword()));
+		user.setRole("USER");
+		return user;
+	}
+
+}

--- a/src/main/java/com/ozeken/expensecalendar/repository/UserMapper.java
+++ b/src/main/java/com/ozeken/expensecalendar/repository/UserMapper.java
@@ -11,7 +11,7 @@ public interface UserMapper {
 	/**ユーザー名からユーザーを取得*/
 	AppUser selectByUsername(@Param("username") String username);
 	
-	/**ユーザーを登録*/
+	/**ユーザー名からユーザーを取得*/
 	void insertUser(AppUser user);
 
 }

--- a/src/main/java/com/ozeken/expensecalendar/repository/UserMapper.java
+++ b/src/main/java/com/ozeken/expensecalendar/repository/UserMapper.java
@@ -1,0 +1,17 @@
+package com.ozeken.expensecalendar.repository;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import com.ozeken.expensecalendar.entity.AppUser;
+
+@Mapper
+public interface UserMapper {
+	
+	/**ユーザー名からユーザーを取得*/
+	AppUser selectByUsername(@Param("username") String username);
+	
+	/**ユーザーを登録*/
+	void insertUser(AppUser user);
+
+}

--- a/src/main/java/com/ozeken/expensecalendar/service/LoginUserDetailsServiceImpl.java
+++ b/src/main/java/com/ozeken/expensecalendar/service/LoginUserDetailsServiceImpl.java
@@ -1,0 +1,33 @@
+package com.ozeken.expensecalendar.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.ozeken.expensecalendar.entity.AppUser;
+import com.ozeken.expensecalendar.entity.LoginUser;
+import com.ozeken.expensecalendar.repository.UserMapper;
+
+@Service
+public class LoginUserDetailsServiceImpl implements UserDetailsService {
+
+	@Autowired
+    private UserMapper userMapper;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+    	
+        // ユーザー名からDB検索
+        AppUser user = userMapper.selectByUsername(username);
+        
+        // ユーザーが存在しない場合は例外をスロー
+        		if (user == null) {
+			throw new UsernameNotFoundException("ユーザーが存在しません: " + username);
+        		}
+        		
+        // LoginUserはUserDetailsを実装を実装したUserクラスを継承している	
+        return new LoginUser(user);
+    }
+}

--- a/src/main/java/com/ozeken/expensecalendar/service/RegisterService.java
+++ b/src/main/java/com/ozeken/expensecalendar/service/RegisterService.java
@@ -1,0 +1,29 @@
+package com.ozeken.expensecalendar.service;
+
+import org.springframework.stereotype.Service;
+
+import com.ozeken.expensecalendar.entity.AppUser;
+import com.ozeken.expensecalendar.form.RegisterForm;
+import com.ozeken.expensecalendar.helper.LoginHelper;
+import com.ozeken.expensecalendar.repository.UserMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RegisterService {
+
+    private final UserMapper userMapper;
+    private final LoginHelper loginHelper;
+
+    /** ユーザー名の重複チェック*/
+    public boolean isDuplicateUsername(String username) {
+        return userMapper.selectByUsername(username) != null;
+    }
+
+    /** ユーザー登録処理*/
+    public void register(RegisterForm form) {
+        AppUser user = loginHelper.convertToAppUser(form);
+        userMapper.insertUser(user);
+    }
+}

--- a/src/main/java/com/ozeken/expensecalendar/util/PasswordGenerator.java
+++ b/src/main/java/com/ozeken/expensecalendar/util/PasswordGenerator.java
@@ -7,7 +7,7 @@ public class PasswordGenerator {
     public static void main(String[] args) {
         PasswordEncoder encoder = new BCryptPasswordEncoder();
         
-        String rawPassword = "adminpassword";
+        String rawPassword = "3"; // ここに生成したいパスワードを入力
         String encodedPassword = encoder.encode(rawPassword);
 
         System.out.println("元のパスワード: " + rawPassword);

--- a/src/main/java/com/ozeken/expensecalendar/util/PasswordGenerator.java
+++ b/src/main/java/com/ozeken/expensecalendar/util/PasswordGenerator.java
@@ -1,0 +1,16 @@
+package com.ozeken.expensecalendar.util;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+public class PasswordGenerator {
+    public static void main(String[] args) {
+        PasswordEncoder encoder = new BCryptPasswordEncoder();
+        
+        String rawPassword = "adminpassword";
+        String encodedPassword = encoder.encode(rawPassword);
+
+        System.out.println("元のパスワード: " + rawPassword);
+        System.out.println("ハッシュ化されたパスワード: " + encodedPassword);
+    }
+}

--- a/src/main/resources/com/ozeken/expensecalendar/repository/UserMapper.xml
+++ b/src/main/resources/com/ozeken/expensecalendar/repository/UserMapper.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.ozeken.expensecalendar.repository.UserMapper">
+
+    <select id="selectByUsername" resultType="com.ozeken.expensecalendar.entity.AppUser">
+        SELECT
+          id,
+          username,
+          password,
+          role
+        FROM
+          users
+        WHERE
+          username = #{username}
+      </select>
+      
+      <insert id="insertUser" parameterType="com.ozeken.expensecalendar.entity.AppUser">
+        INSERT INTO users (username, password, role)
+        VALUES (#{username}, #{password}, #{role})
+    </insert>
+      
+</mapper>

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -11,3 +11,9 @@ VALUES
 ('2025-06-08', '娯楽', 1000, 'ランチ代'),
 ('2025-06-13', '交通費', 500, 'バス代'),
 ('2025-06-25', '食費', 2000, '映画チケット');
+
+-- ユーザーデータの挿入
+INSERT INTO users (username, password, role)
+VALUES 
+('admin', '$2a$10$H/H.MtfUyYHfC3/LADAUTex79lpcff4qtlFO.SuXxlOQDOZNnXlbu', 'ADMIN')  -- パスワードは 'adminpassword' のハッシュ
+ON CONFLICT (username) DO NOTHING;

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -15,5 +15,7 @@ VALUES
 -- ユーザーデータの挿入
 INSERT INTO users (username, password, role)
 VALUES 
-('admin', '$2a$10$H/H.MtfUyYHfC3/LADAUTex79lpcff4qtlFO.SuXxlOQDOZNnXlbu', 'ADMIN')  -- パスワードは 'adminpassword' のハッシュ
+('user1','$2a$10$er93XnfZ3P62/.KRbXLrf.9wdZaIO35n6sQHHdB6jhrGCqqX0sb0u', 'USER'),
+('user2','$2a$10$OtijxZbUIfomg8p3w0gDyey50F6I41elanLP.tiC.vqp2l2BQa6TW', 'USER'),
+('user3',' $2a$10$aCOrvlmjb9R7u6hjAbw8O.ht3mRLBVcjJfPdGjLlA2duKdrANMMBG', 'USER')
 ON CONFLICT (username) DO NOTHING;

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -4,7 +4,8 @@ CREATE TABLE IF NOT EXISTS expenses (
     date           DATE NOT NULL,                --  日付
     category    VARCHAR(50) NOT NULL,  --  カテゴリ
     amount      INTEGER NOT NULL,           --  金額
-    description TEXT                                    --  説明
+    description TEXT,                                    --  説明
+    CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE --  ユーザーID
 );
 
 CREATE TABLE IF NOT EXISTS users (

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -6,3 +6,10 @@ CREATE TABLE IF NOT EXISTS expenses (
     amount      INTEGER NOT NULL,           --  金額
     description TEXT                                    --  説明
 );
+
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    username VARCHAR(50) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL,
+    role VARCHAR(20) DEFAULT 'USER'
+);

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -1,0 +1,48 @@
+<!-- templates/index.html -->
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>家計簿アプリ</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+</head>
+<body>
+    <header>
+        <h1>家計簿アプリを始めましょう！</h1>
+        <nav>
+            <a th:href="@{/login}">ログイン</a> |
+            <a th:href="@{/register}">新規登録</a>
+        </nav>
+    </header>
+
+    <main>
+        <section>
+            <h2>このアプリでできること</h2>
+            <ul>
+                <li>カレンダー形式で支出を記録・確認</li>
+                <li>月ごとの支出集計</li>
+                <li>カテゴリ別の支出管理</li>
+            </ul>
+        </section>
+
+        <section>
+            <h2>使い方の流れ</h2>
+            <ol>
+                <li>アカウント登録</li>
+                <li>ログインして支出を入力</li>
+                <li>月ごとの支出をカレンダーで確認</li>
+            </ol>
+        </section>
+
+        <section>
+            <h2>まずはログインまたは新規登録</h2>
+            <a th:href="@{/login}" class="btn">ログイン</a>
+            <a th:href="@{/register}" class="btn">新規登録</a>
+        </section>
+    </main>
+
+    <footer>
+        <p>&copy; 2025 家計簿アプリ</p>
+    </footer>
+</body>
+</html>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,0 +1,46 @@
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>ログイン - 家計簿アプリ</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+</head>
+<body>
+    <h1>ログイン</h1>
+
+    <!-- ログインフォーム -->
+    <form th:action="@{/login}" method="post">
+        <div>
+            <label for="username">ユーザー名：</label>
+            <input type="text" id="username" name="username" required />
+        </div>
+
+        <div>
+            <label for="password">パスワード：</label>
+            <input type="password" id="password" name="password" required />
+        </div>
+        
+        <div>
+                <label>
+                    <input type="checkbox" name="remember-me" />
+                    ログイン状態を保持する
+                </label>
+         </div>
+
+        <div>
+            <button type="submit">ログイン</button>
+        </div>
+    </form>
+
+    <!-- ログインエラー時 -->
+    <div th:if="${param.error}">
+        <p style="color: red;">ユーザー名またはパスワードが間違っています。</p>
+    </div>
+
+    <!-- ログアウト後 -->
+    <div th:if="${param.logout}">
+        <p style="color: green;">ログアウトしました。</p>
+    </div>
+
+    <p>アカウントをお持ちでない方は <a th:href="@{/register}">新規登録</a> へ</p>
+</body>
+</html>

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>ユーザー登録</title>
+</head>
+<body>
+    <h1>ユーザー登録フォーム</h1>
+    
+    <!-- エラーメッセージがある場合に表示 -->
+        <p th:if="${errorMessage}" th:text="${errorMessage}" style="color:red;"></p>
+    
+    <form th:action="@{/register}" method="post" th:object="${registerForm}">
+        <label for="username">ユーザー名：</label>
+        <input type="text" th:field="*{username}" /><br />
+        <span th:if="${#fields.hasErrors('username')}" th:errors="*{username}" style="color:red"></span>
+        <br/>
+
+        <label for="password">パスワード：</label>
+        <input type="password" th:field="*{password}" /><br />
+        <span th:if="${#fields.hasErrors('password')}" th:errors="*{password}" style="color:red"></span>
+        <br/>
+
+        <input type="submit" value="登録" />
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## 概要
- ユーザー登録画面とControllerの追加
- RegisterForm（バリデーション付き）、LoginHelper、RegisterServiceの追加
- PasswordEncoderによるパスワードハッシュ保存
- Spring Securityの設定追加（未ログインで"/", "/login", "/register", "/css/**"は許可）

## マージについて
- mainブランチの「spring-boot-starter-security」依存関係をマージ済み
- 自動マージ不可のため、競合は手動で解決予定

## 今後の予定
- ログイン機能の実装と認証済みユーザーのホーム画面表示