### PR TITLE
ログインユーザーに紐づく支出データのみを操作対象とするよう変更

### DIFF
--- a/src/main/java/com/ozeken/expensecalendar/controller/CalendarViewController.java
+++ b/src/main/java/com/ozeken/expensecalendar/controller/CalendarViewController.java
@@ -3,6 +3,7 @@ package com.ozeken.expensecalendar.controller;
 import java.time.LocalDate;
 import java.util.List;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.ozeken.expensecalendar.entity.Expense;
+import com.ozeken.expensecalendar.entity.LoginUser;
 import com.ozeken.expensecalendar.service.ExpenseService;
 
 import lombok.RequiredArgsConstructor;
@@ -29,7 +31,8 @@ public class CalendarViewController {
     public String showCalendar(
             @RequestParam(value = "year", required = false) Integer year,
             @RequestParam(value = "month", required = false) Integer month,
-            Model model) {
+            Model model,
+            @AuthenticationPrincipal LoginUser loginUser) {
 
     	//nullの場合は,今日の年月を取得
         LocalDate today = LocalDate.now();
@@ -43,8 +46,13 @@ public class CalendarViewController {
         LocalDate prevMonth = firstDay.minusMonths(1);
         LocalDate nextMonth = firstDay.plusMonths(1);
 
+     // 指定された年月の家計簿を取得
+        if (loginUser.getAppUser() == null) {
+            return "redirect:/login";
+        }
         //指定された年月の家計簿を取得
-        List<Expense> expenses = expenseService.findByMonth(currentYear, currentMonth);
+        Long userId = loginUser.getAppUser().getId();
+        List<Expense> expenses = expenseService.findByMonth(userId,currentYear, currentMonth);
         
         //月初日を取得し,日曜始まりへと変換
         int firstDayOfWeek = firstDay.getDayOfWeek().getValue();

--- a/src/main/java/com/ozeken/expensecalendar/entity/Expense.java
+++ b/src/main/java/com/ozeken/expensecalendar/entity/Expense.java
@@ -10,6 +10,9 @@ public class Expense {
 	// ID
 	private Long id;
 
+	// ユーザーID (外部キー)
+	private Long userId;
+
 	// 日付
 	private LocalDate date;
 

--- a/src/main/java/com/ozeken/expensecalendar/entity/LoginUser.java
+++ b/src/main/java/com/ozeken/expensecalendar/entity/LoginUser.java
@@ -21,6 +21,12 @@ public class LoginUser extends User {
         );
         this.appUser = appUser;
     }
+    
+ // ★Springの内部処理用（@AuthenticationPrincipalなどで使われる）
+    public LoginUser() {
+        super("anonymous", "", List.of());
+        this.appUser = null;
+    }
 
     public AppUser getAppUser() {
         return appUser;

--- a/src/main/java/com/ozeken/expensecalendar/form/ExpenseForm.java
+++ b/src/main/java/com/ozeken/expensecalendar/form/ExpenseForm.java
@@ -16,6 +16,9 @@ public class ExpenseForm {
 	// ID
 	private Long id;
 
+	// ユーザーID（外部キー）
+	private Long userId;
+
 	// 日付
 	@NotNull(message = "日付を入力して下さい")
 	private LocalDate date;

--- a/src/main/java/com/ozeken/expensecalendar/helper/ExpenseHelper.java
+++ b/src/main/java/com/ozeken/expensecalendar/helper/ExpenseHelper.java
@@ -14,6 +14,7 @@ public class ExpenseHelper {
     public static Expense convertExpense(ExpenseForm form) {
         Expense expense = new Expense();
         expense.setId(form.getId());
+        expense.setUserId(form.getUserId());
         expense.setDate(form.getDate());
         expense.setCategory(form.getCategory());
         expense.setAmount(form.getAmount());
@@ -27,6 +28,7 @@ public class ExpenseHelper {
     public static ExpenseForm convertExpenseForm(Expense expense) {
         ExpenseForm form = new ExpenseForm();
         form.setId(expense.getId());
+        form.setUserId(expense.getUserId());
         form.setDate(expense.getDate());
         form.setCategory(expense.getCategory());
         form.setAmount(expense.getAmount());

--- a/src/main/java/com/ozeken/expensecalendar/repository/ExpenseMapper.java
+++ b/src/main/java/com/ozeken/expensecalendar/repository/ExpenseMapper.java
@@ -3,28 +3,28 @@ package com.ozeken.expensecalendar.repository;
 import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import com.ozeken.expensecalendar.entity.Expense;
 
 @Mapper
 public interface ExpenseMapper {
 
-	// 全件取得
-	List<Expense> selectAll();
+	// ログインユーザーの全件取得
+	List<Expense> selectAll(@Param("userId") Long userId);
 	
 	// 月別取得
-	List<Expense> selectByMonth(int year, int month);
+	List<Expense> selectByMonth(@Param("userId") Long userId, @Param("year") int year, @Param("month") int month);
 
-	// IDで一件取得
-	Expense selectById(Long id);
+	// IDとuserIdで取得（安全な取得）
+	Expense selectByIdAndUserId(@Param("id") Long id, @Param("userId") Long userId);
 
 	// 新規登録
 	void insert(Expense expense);
 
-	// 更新
+	// 更新（userIdを含むバリデーションはサービス層で行う）
 	void update(Expense expense);
 
-	// 削除
-	void delete(Long id);
-
+	// IDとuserIdで削除（安全な削除）
+	void deleteByIdAndUserId(@Param("id") Long id, @Param("userId") Long userId);
 }

--- a/src/main/java/com/ozeken/expensecalendar/service/ExpenseService.java
+++ b/src/main/java/com/ozeken/expensecalendar/service/ExpenseService.java
@@ -7,25 +7,24 @@ import com.ozeken.expensecalendar.entity.Expense;
 
 public interface ExpenseService {
 
-	// 全件取得
-	List<Expense> findAll();
+	// ログインユーザーの全件取得
+	List<Expense> findAll(Long userId);
 	
-	// 月別取得
-	List<Expense> findByMonth(int year, int month);
+	// 月別取得（ユーザー指定）
+	List<Expense> findByMonth(Long userId, int year, int month);
 	
-	//年月で取得し、日にちでグループ化
-	Map<Integer, List<Expense>> groupByDayOfMonth(int currentYear, int currentMonth);
+	// 年月で取得し、日にちでグループ化（ユーザー指定）
+	Map<Integer, List<Expense>> groupByDayOfMonth(Long userId, int currentYear, int currentMonth);
 	
 	// IDで一件取得
-	Expense findById(Long id);
+	Expense findById(Long id, Long userId);
 
-	// 新規登録
+	// 新規登録（Expense に userId を含む前提）
 	void insert(Expense expense);
 
 	// 更新
 	void update(Expense expense);
 
 	// 削除
-	void delete(Long id);
-
+	void delete(Long id, Long userId);
 }

--- a/src/main/java/com/ozeken/expensecalendar/service/ExpenseServiceImpl.java
+++ b/src/main/java/com/ozeken/expensecalendar/service/ExpenseServiceImpl.java
@@ -19,49 +19,47 @@ public class ExpenseServiceImpl implements ExpenseService {
 
 	/**DI*/
 	private final ExpenseMapper expenseMapper;
-	
+
+	// ログインユーザーの全件取得
 	@Override
-	public List<Expense> findAll() {
-		return expenseMapper.selectAll();
+	public List<Expense> findAll(Long userId) {
+		return expenseMapper.selectAll(userId);
 	}
-	
+
+	// 月別取得 （ユーザー指定）
 	@Override
-	public List<Expense> findByMonth(int year, int month) {
-		return expenseMapper.selectByMonth(year, month);
+	public List<Expense> findByMonth(Long userId, int year, int month) {
+		return expenseMapper.selectByMonth(userId, year, month);
 	}
 
 	@Override
     // カレンダー表示用：日別に支出をまとめる
-    public Map<Integer, List<Expense>> groupByDayOfMonth(int year, int month) {
-        List<Expense> expenses = findByMonth(year, month);
+    public Map<Integer, List<Expense>> groupByDayOfMonth(Long userId, int year, int month) {
+        List<Expense> expenses = findByMonth(userId, year, month);
         //streamでデータを流し込み、getDateで年月日を取得、
         //getDayOfMonthで日にちのみ(1~31の整数)を取得、Collectors.groupingByでグループ化(mapの形式に変換)
         return expenses.stream().collect(Collectors.groupingBy(exp -> exp.getDate().getDayOfMonth()));
     }
 
+	// IDとuserIdで一件取得（他人のデータ保護）
 	@Override
-	public Expense findById(Long id) {
-		return expenseMapper.selectById(id);
+	public Expense findById(Long id, Long userId) {
+		return expenseMapper.selectByIdAndUserId(id, userId);
 	}
 
 	@Override
 	public void insert(Expense expense) {
 		expenseMapper.insert(expense);
-
 	}
 
 	@Override
 	public void update(Expense expense) {
 		expenseMapper.update(expense);
-
 	}
 
+	// IDとuserIdで削除（他人のデータ削除を防止）
 	@Override
-	public void delete(Long id) {
-		expenseMapper.delete(id);
-
+	public void delete(Long id, Long userId) {
+		expenseMapper.deleteByIdAndUserId(id, userId);
 	}
-
-	
-
 }

--- a/src/main/resources/com/ozeken/expensecalendar/repository/ExpenseMapper.xml
+++ b/src/main/resources/com/ozeken/expensecalendar/repository/ExpenseMapper.xml
@@ -2,34 +2,35 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.ozeken.expensecalendar.repository.ExpenseMapper">
     
-    <!-- 全件取得 -->
+  <!-- 全件取得 -->
   <select id="selectAll" resultType="com.ozeken.expensecalendar.entity.Expense">
-    SELECT id, date, category, amount, description
+    SELECT id, user_id, date, category, amount, description
     FROM expenses
+    WHERE user_id = #{userId}
     ORDER BY date DESC
   </select>
   
   <!-- 年月で絞り込む -->
   <select id="selectByMonth" resultType="com.ozeken.expensecalendar.entity.Expense">
-    SELECT id, date, category, amount, description
+    SELECT id, user_id, date, category, amount, description
     FROM expenses
-    WHERE EXTRACT(YEAR FROM date) = #{year}
+    WHERE user_id = #{userId}
+      AND EXTRACT(YEAR FROM date) = #{year}
       AND EXTRACT(MONTH FROM date) = #{month}
     ORDER BY date
   </select>
   
-
-  <!-- IDで一件取得 -->
-  <select id="selectById" resultType="com.ozeken.expensecalendar.entity.Expense">
-    SELECT id, date, category, amount, description
+  <!-- IDで一件取得  -->
+  <select id="selectByIdAndUserId" resultType="com.ozeken.expensecalendar.entity.Expense">
+    SELECT id, user_id, date, category, amount, description
     FROM expenses
-    WHERE id = #{id}
+    WHERE id = #{id} AND user_id = #{userId}
   </select>
 
   <!-- 新規登録 -->
   <insert id="insert" useGeneratedKeys="true" keyProperty="id">
-    INSERT INTO expenses (date, category, amount, description)
-    VALUES (#{date}, #{category}, #{amount}, #{description})
+    INSERT INTO expenses (user_id, date, category, amount, description)
+    VALUES (#{userId}, #{date}, #{category}, #{amount}, #{description})
   </insert>
 
   <!-- 更新 -->
@@ -39,12 +40,13 @@
         category = #{category},
         amount = #{amount},
         description = #{description}
-    WHERE id = #{id}
+    WHERE id = #{id} AND user_id = #{userId}
   </update>
 
   <!-- 削除 -->
-  <delete id="delete">
-    DELETE FROM expenses WHERE id = #{id}
+  <delete id="deleteByIdAndUserId">
+    DELETE FROM expenses
+    WHERE id = #{id} AND user_id = #{userId}
   </delete>
   
 </mapper>

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,21 +1,21 @@
-INSERT INTO expenses (date, category, amount, description)
-VALUES 
-('2025-04-02', '食費', 1000, 'ランチ代'),
-('2025-04-17', '交通費', 500, 'バス代'),
-('2025-04-19', '娯楽', 2000, '映画チケット'),
-
-('2025-05-01', '交通費', 1000, 'ランチ代'),
-('2025-05-04', '食費', 500, 'バス代'),
-('2025-05-15', '娯楽', 2000, '映画チケット'),
-
-('2025-06-08', '娯楽', 1000, 'ランチ代'),
-('2025-06-13', '交通費', 500, 'バス代'),
-('2025-06-25', '食費', 2000, '映画チケット');
-
 -- ユーザーデータの挿入
-INSERT INTO users (username, password, role)
+INSERT INTO users (id, username, password, role)
 VALUES 
-('user1','$2a$10$er93XnfZ3P62/.KRbXLrf.9wdZaIO35n6sQHHdB6jhrGCqqX0sb0u', 'USER'),
-('user2','$2a$10$OtijxZbUIfomg8p3w0gDyey50F6I41elanLP.tiC.vqp2l2BQa6TW', 'USER'),
-('user3',' $2a$10$aCOrvlmjb9R7u6hjAbw8O.ht3mRLBVcjJfPdGjLlA2duKdrANMMBG', 'USER')
+(1,'user1','$2a$10$er93XnfZ3P62/.KRbXLrf.9wdZaIO35n6sQHHdB6jhrGCqqX0sb0u', 'USER'),
+(2,'user2','$2a$10$OtijxZbUIfomg8p3w0gDyey50F6I41elanLP.tiC.vqp2l2BQa6TW', 'USER'),
+(3,'user3','$2a$10$aCOrvlmjb9R7u6hjAbw8O.ht3mRLBVcjJfPdGjLlA2duKdrANMMBG', 'USER')
 ON CONFLICT (username) DO NOTHING;
+
+INSERT INTO expenses (user_id,date, category, amount, description)
+VALUES 
+(1,'2025-04-02', '食費', 1000, 'ランチ代'),
+(1,'2025-04-17', '交通費', 500, 'バス代'),
+(1,'2025-04-19', '娯楽', 2000, '映画チケット'),
+
+(1,'2025-05-01', '交通費', 1000, 'ランチ代'),
+(1,'2025-05-04', '食費', 500, 'バス代'),
+(1,'2025-05-15', '娯楽', 2000, '映画チケット'),
+
+(1,'2025-06-08', '娯楽', 1000, 'ランチ代'),
+(1,'2025-06-13', '交通費', 500, 'バス代'),
+(1,'2025-06-25', '食費', 2000, '映画チケット');

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,16 +1,18 @@
--- 支出テーブルを作成
-CREATE TABLE IF NOT EXISTS expenses (
-    id               BIGSERIAL PRIMARY KEY,  --  ID
-    date           DATE NOT NULL,                --  日付
-    category    VARCHAR(50) NOT NULL,  --  カテゴリ
-    amount      INTEGER NOT NULL,           --  金額
-    description TEXT,                                    --  説明
-    CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE --  ユーザーID
-);
-
+--ユーザーテーブルを作成
 CREATE TABLE IF NOT EXISTS users (
     id SERIAL PRIMARY KEY,
     username VARCHAR(50) NOT NULL UNIQUE,
     password VARCHAR(255) NOT NULL,
     role VARCHAR(20) DEFAULT 'USER'
+);
+
+-- 支出テーブルを作成
+CREATE TABLE IF NOT EXISTS expenses (
+    id          BIGSERIAL PRIMARY KEY,           -- ID
+    user_id     INTEGER NOT NULL,                -- ユーザーID（外部キー）
+    date        DATE NOT NULL,                       -- 日付
+    category    VARCHAR(50) NOT NULL,      -- カテゴリ
+    amount      INTEGER NOT NULL,               -- 金額
+    description TEXT,                                       -- 説明
+    CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );

--- a/src/test/java/com/ozeken/expensecalendar/controller/CalendarViewControllerTest.java
+++ b/src/test/java/com/ozeken/expensecalendar/controller/CalendarViewControllerTest.java
@@ -25,7 +25,8 @@ public class CalendarViewControllerTest {
     @Test
     public void testShowCalendar() throws Exception {
         // groupByDayOfMonthの戻り値をダミーにする
-        org.mockito.Mockito.when(expenseService.groupByDayOfMonth(2025, 5))
+    	Long userId = 1L; // テスト用のユーザーID
+        org.mockito.Mockito.when(expenseService.groupByDayOfMonth(userId,2025, 5))
             .thenReturn(Collections.emptyMap());
 
         mockMvc.perform(get("/expenses/calendar")

--- a/src/test/java/com/ozeken/expensecalendar/service/ExpenseServiceImplTest.java
+++ b/src/test/java/com/ozeken/expensecalendar/service/ExpenseServiceImplTest.java
@@ -19,18 +19,22 @@ class ExpenseServiceImplTest {
 	@Autowired
 	private ExpenseServiceImpl expenseService;
 
+	// テスト用のユーザーID（テストDBに事前に存在する想定）
+	private final Long TEST_USER_ID = 1L;
+
 	@Test
 	void shouldGetAllExpenses() {
-		List<Expense> expenses = expenseService.findAll();
+		// 全件取得
+		List<Expense> expenses = expenseService.findAll(TEST_USER_ID);
 		// nullでないことを確認
 		assertThat(expenses).isNotNull();
 	}
 
 	@Test
 	void shouldInsertExpense() {
-
 		// 登録
 		Expense expense = new Expense();
+		expense.setUserId(TEST_USER_ID); // ★ ユーザーIDをセット
 		expense.setDate(LocalDate.now());
 		expense.setCategory("テストカテゴリ");
 		expense.setAmount(1234);
@@ -38,7 +42,7 @@ class ExpenseServiceImplTest {
 
 		expenseService.insert(expense);
 
-		List<Expense> expenses = expenseService.findAll();
+		List<Expense> expenses = expenseService.findAll(TEST_USER_ID);
 		assertThat(expenses)
 				// 登録したデータが取得できること
 				.extracting(Expense::getCategory).contains("テストカテゴリ");
@@ -46,7 +50,9 @@ class ExpenseServiceImplTest {
 
 	@Test
 	void shouldUpdateExpense() {
+		// 更新対象を作成
 		Expense expense = new Expense();
+		expense.setUserId(TEST_USER_ID);
 		expense.setDate(LocalDate.now());
 		expense.setCategory("更新前カテゴリ");
 		expense.setAmount(5678);
@@ -54,19 +60,23 @@ class ExpenseServiceImplTest {
 
 		expenseService.insert(expense);
 
-		List<Expense> expenses = expenseService.findAll();
+		List<Expense> expenses = expenseService.findAll(TEST_USER_ID);
 		Expense target = expenses.get(expenses.size() - 1);
 		target.setCategory("更新後カテゴリ");
 
+		// 更新
 		expenseService.update(target);
 
-		Expense updated = expenseService.findById(target.getId());
+		Expense updated = expenseService.findById(target.getId(), TEST_USER_ID);
+		// カテゴリが更新されていることを確認
 		assertThat(updated.getCategory()).isEqualTo("更新後カテゴリ");
 	}
 
 	@Test
 	void shouldDeleteExpense() {
+		// 削除対象を作成
 		Expense expense = new Expense();
+		expense.setUserId(TEST_USER_ID);
 		expense.setDate(LocalDate.now());
 		expense.setCategory("削除対象カテゴリ");
 		expense.setAmount(9999);
@@ -74,13 +84,14 @@ class ExpenseServiceImplTest {
 
 		expenseService.insert(expense);
 
-		List<Expense> expenses = expenseService.findAll();
+		List<Expense> expenses = expenseService.findAll(TEST_USER_ID);
 		Expense target = expenses.get(expenses.size() - 1);
 
 		// 削除
-		expenseService.delete(target.getId());
+		expenseService.delete(target.getId(), TEST_USER_ID);
 
-		Expense deleted = expenseService.findById(target.getId());
+		Expense deleted = expenseService.findById(target.getId(), TEST_USER_ID);
+		// 削除されていることを確認
 		assertThat(deleted).isNull();
 	}
 }


### PR DESCRIPTION
## 概要
ログインしているユーザー本人の支出データのみを閲覧・編集・削除できるように制限しました。
セキュリティの観点から、他ユーザーのデータにアクセスできないよう対策を行っています。

## 主な変更点
- Expenseエンティティ・フォームに `userId` を追加
- `@AuthenticationPrincipal` を用いてログインユーザーを取得
- Service / Mapper層で `userId` によるフィルタリングを実装
- SQLスキーマ・テストデータを `user_id` 対応に修正
- テストコードも `userId` を考慮するよう調整