### PR TITLE
カレンダー画面に日別の支出合計金額を表示する機能を追加

### DIFF
--- a/src/main/java/com/ozeken/expensecalendar/controller/CalendarViewController.java
+++ b/src/main/java/com/ozeken/expensecalendar/controller/CalendarViewController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import com.ozeken.expensecalendar.dto.DailyTotal;
 import com.ozeken.expensecalendar.dto.ExpenseWithGenre;
 import com.ozeken.expensecalendar.entity.LoginUser;
 import com.ozeken.expensecalendar.service.ExpenseService;
@@ -53,8 +54,8 @@ public class CalendarViewController {
         //指定された年月の家計簿を取得
         Long userId = loginUser.getAppUser().getId();
         List<ExpenseWithGenre> expenses = expenseService.findByMonth(userId,currentYear, currentMonth);
-        
-        System.out.println(expenses);
+        //指定された年月の日別合計を取得
+        List<DailyTotal> dailyTotals = expenseService.findDailyTotalByMonth(userId, currentYear, currentMonth);
         
         //月初日を取得し,日曜始まりへと変換
         int firstDayOfWeek = firstDay.getDayOfWeek().getValue();
@@ -65,6 +66,7 @@ public class CalendarViewController {
         model.addAttribute("year", currentYear);
         model.addAttribute("month", currentMonth);
         model.addAttribute("expenses", expenses);
+        model.addAttribute("dailyTotals", dailyTotals);
         model.addAttribute("firstDayOfWeek", firstDayOfWeek);
         model.addAttribute("daysInMonth", daysInMonth);
         // 前月・次月の年月を渡す

--- a/src/main/java/com/ozeken/expensecalendar/dto/DailyTotal.java
+++ b/src/main/java/com/ozeken/expensecalendar/dto/DailyTotal.java
@@ -1,0 +1,14 @@
+package com.ozeken.expensecalendar.dto;
+
+import lombok.Data;
+
+@Data
+public class DailyTotal {
+	
+	// 日付
+	private int day;
+	
+	// 合計金額
+	private Integer total;
+	
+}

--- a/src/main/java/com/ozeken/expensecalendar/repository/ExpenseMapper.java
+++ b/src/main/java/com/ozeken/expensecalendar/repository/ExpenseMapper.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import com.ozeken.expensecalendar.dto.DailyTotal;
 import com.ozeken.expensecalendar.dto.ExpenseWithGenre;
 import com.ozeken.expensecalendar.entity.Expense;
 
@@ -22,6 +23,9 @@ public interface ExpenseMapper {
 	
 	// 月別取得
 	List<ExpenseWithGenre> selectByMonth(@Param("userId") Long userId, @Param("year") int year, @Param("month") int month);
+	
+	//日付合計取得
+	List<DailyTotal> selectDailyTotalByMonth(@Param("userId") Long userId, @Param("year") int year, @Param("month") int month);
 	
 	// 新規登録
 	void insert(Expense expense);

--- a/src/main/java/com/ozeken/expensecalendar/service/ExpenseService.java
+++ b/src/main/java/com/ozeken/expensecalendar/service/ExpenseService.java
@@ -3,6 +3,7 @@ package com.ozeken.expensecalendar.service;
 import java.util.List;
 import java.util.Map;
 
+import com.ozeken.expensecalendar.dto.DailyTotal;
 import com.ozeken.expensecalendar.dto.ExpenseWithGenre;
 import com.ozeken.expensecalendar.entity.Expense;
 
@@ -19,6 +20,9 @@ public interface ExpenseService {
 	
 	// 月別取得（ユーザー指定）
 	List<ExpenseWithGenre> findByMonth(Long userId, int year, int month);
+	
+	// 日付合計取得（ユーザー指定）
+	List<DailyTotal> findDailyTotalByMonth(Long userId, int year, int month);
 	
 	// 年月で取得し、日にちでグループ化（ユーザー指定）
 	Map<Integer, List<ExpenseWithGenre>> groupByDayOfMonth(Long userId, int currentYear, int currentMonth);

--- a/src/main/java/com/ozeken/expensecalendar/service/impl/ExpenseServiceImpl.java
+++ b/src/main/java/com/ozeken/expensecalendar/service/impl/ExpenseServiceImpl.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.ozeken.expensecalendar.dto.DailyTotal;
 import com.ozeken.expensecalendar.dto.ExpenseWithGenre;
 import com.ozeken.expensecalendar.entity.Expense;
 import com.ozeken.expensecalendar.repository.ExpenseMapper;
@@ -22,7 +23,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 	/**DI*/
 	private final ExpenseMapper expenseMapper;
 	
-	
+	// ------- 取得 --------
 	@Override
 	public List<ExpenseWithGenre> findAllWithGenre(Long userId) {
 	    return expenseMapper.selectWithGenreByUserId(userId);
@@ -38,10 +39,16 @@ public class ExpenseServiceImpl implements ExpenseService {
 		return expenseMapper.selectByIdAndUserId(id, userId);
 	}
 	
-	// 月別取得 （ユーザー指定）
+	// 月別取得
 	@Override
 	public List<ExpenseWithGenre> findByMonth(Long userId, int year, int month) {
 		return expenseMapper.selectByMonth(userId, year, month);
+	}
+	
+	// 日付合計取得
+	@Override
+	public List<DailyTotal> findDailyTotalByMonth(Long userId, int year, int month) {
+		return expenseMapper.selectDailyTotalByMonth(userId, year, month);
 	}
 
 	@Override
@@ -52,7 +59,9 @@ public class ExpenseServiceImpl implements ExpenseService {
         //getDayOfMonthで日にちのみ(1~31の整数)を取得、Collectors.groupingByでグループ化(mapの形式に変換)
         return expenses.stream().collect(Collectors.groupingBy(exp -> exp.getDate().getDayOfMonth()));
     }
-
+	
+	
+	// ------- 登録・更新・削除 --------
 	@Override
 	public void insert(Expense expense) {
 		expenseMapper.insert(expense);
@@ -63,7 +72,6 @@ public class ExpenseServiceImpl implements ExpenseService {
 		expenseMapper.update(expense);
 	}
 
-	// IDとuserIdで削除（他人のデータ削除を防止）
 	@Override
 	public void delete(Long id, Long userId) {
 		expenseMapper.deleteByIdAndUserId(id, userId);

--- a/src/main/resources/com/ozeken/expensecalendar/repository/ExpenseMapper.xml
+++ b/src/main/resources/com/ozeken/expensecalendar/repository/ExpenseMapper.xml
@@ -13,6 +13,11 @@
   <result property="description" column="description"/>
 </resultMap>
 
+<resultMap id="DailyTotalMap" type="com.ozeken.expensecalendar.dto.DailyTotal">
+    <result property="day" column="day"/>
+    <result property="total" column="total"/>
+</resultMap>
+
   <!-- ジャンル名付きで支出一覧を取得 -->
 <select id="selectWithGenreByUserId" resultMap="ExpenseWithGenreMap">
   SELECT
@@ -50,10 +55,13 @@
         JOIN genres g ON e.genre_id = g.id
         WHERE e.id = #{id} AND e.user_id = #{userId}
         ORDER BY e.date DESC
-       </select>
+    </select>
        
-  <!-- 年月で絞り込む -->
-  <select id="selectByMonth" resultMap="ExpenseWithGenreMap">
+<!-- 
+  指定された年月における、全支出明細（ジャンル名付き）を取得するSQL。
+  支出一覧やカレンダーの詳細表示に使用される。
+-->
+<select id="selectByMonth" resultMap="ExpenseWithGenreMap">
   SELECT
     e.id,
     e.user_id,
@@ -70,7 +78,22 @@
   ORDER BY e.date
 </select>
 
-  
+<!-- 
+  指定された年月における、日ごとの支出合計金額を取得するSQL。
+  主にカレンダー表示の「日単位の合計金額」などに使用される。
+-->
+<select id="selectDailyTotalByMonth" resultMap="DailyTotalMap">
+  SELECT 
+    EXTRACT(DAY FROM e.date) AS day,
+    SUM(e.amount) AS total
+  FROM expenses e
+  WHERE e.user_id = #{userId}
+    AND EXTRACT(YEAR FROM e.date) = #{year}
+    AND EXTRACT(MONTH FROM e.date) = #{month}
+  GROUP BY day
+  ORDER BY day
+</select>
+
   <!-- 新規登録 -->
   <insert id="insert" useGeneratedKeys="true" keyProperty="id">
     INSERT INTO expenses (user_id, date, genre_id, amount, description)

--- a/src/main/resources/static/css/calendar.css
+++ b/src/main/resources/static/css/calendar.css
@@ -24,7 +24,7 @@ td span {
 }
 
 td .amount {
-    color: red;
+    color: indianred;
     font-weight: bold;
     margin-top: 5px;
 }
@@ -40,3 +40,11 @@ td.empty {
     justify-content: left;
     flex-wrap: wrap;
 }
+
+.total-amount {
+    color:red;
+    font-size: 16px;
+    font-weight: bold;
+    margin-top: 10px;
+}
+    

--- a/src/main/resources/templates/expenses/calendar.html
+++ b/src/main/resources/templates/expenses/calendar.html
@@ -53,6 +53,14 @@
                     <div th:if="${cellIndex >= firstDayOfWeek and dateNum <= daysInMonth}">
                         <span th:text="${dateNum}"></span><br>
 
+
+                        <!-- 合計金額の表示 -->
+                        <span th:each="dailyTotal : ${dailyTotals}"
+                              th:if="${dailyTotal.day == (dateNum)}"
+                              th:text="'合計: ￥' + ${dailyTotal.total}"
+                              class="total-amount">
+                          </span>
+                          
                         <!-- 金額表示 -->
                         <span th:each="expense : ${expenses}"
                               th:if="${expense.date.dayOfMonth == (dateNum)}"


### PR DESCRIPTION
## 概要
カレンダー画面に「日別の支出合計金額」を表示する機能を追加しました。

## 変更内容
- `DailyTotal` DTOを追加
- Mapper・Service層に日別合計を取得する処理を実装
- コントローラで `dailyTotals` を取得してModelに追加
- カレンダーの各日付セルに合計金額を表示（Thymeleaf）
- 合計金額表示用のCSSクラス `.total-amount` を追加