### PR TITLE
fix: プロファイル出力の削除とテストプロファイルの設定

### DIFF
--- a/src/main/java/com/ozeken/expensecalendar/ExpensecalendarApplication.java
+++ b/src/main/java/com/ozeken/expensecalendar/ExpensecalendarApplication.java
@@ -8,10 +8,5 @@ public class ExpensecalendarApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(ExpensecalendarApplication.class, args);
-		
-		// プロファイル確認用ログ
-        String profile = System.getProperty("spring.profiles.active");
-        System.out.println(">>> 起動時プロファイル: " + profile);
 	}
-
 }

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -4,9 +4,6 @@ spring.datasource.username=${JDBC_DATABASE_USERNAME}
 spring.datasource.password=${JDBC_DATABASE_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
-# Hibernate dialect を明示的に指定
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
-
 #SQLスクリプトの初期化の設定
 spring.sql.init.mode=never
 

--- a/src/test/java/com/ozeken/expensecalendar/controller/CalendarViewControllerTest.java
+++ b/src/test/java/com/ozeken/expensecalendar/controller/CalendarViewControllerTest.java
@@ -9,10 +9,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.ozeken.expensecalendar.service.ExpenseService;
 
+@ActiveProfiles("test")
 @WebMvcTest(CalendarViewController.class)
 public class CalendarViewControllerTest {
 


### PR DESCRIPTION
- mainメソッド内の起動時プロファイル出力ログを削除
- 本番用プロパティからHibernateの方言設定を削除
- CalendarViewControllerTestに@ActiveProfiles("test")を追加し、テスト時のプロファイルを明示的に設定