### PR TITLE
style: 家計簿一覧ページのUIスタイルを改善

### DIFF
--- a/src/main/resources/static/css/base.css
+++ b/src/main/resources/static/css/base.css
@@ -70,6 +70,15 @@ a.button {
     display: inline-block;
 }
 
+.button.primary {
+    background-color: #ffb347;
+    color: white;
+}
+
+.button.primary:hover {
+    background-color: #ff9f00;
+}
+
 button:hover,
 a.button:hover {
     background-color: #5cc1bc;

--- a/src/main/resources/static/css/list.css
+++ b/src/main/resources/static/css/list.css
@@ -39,11 +39,19 @@ a.bottom-link {
     color: #777;
 }
 
-.delete {
-    background-color: #f08080 !important;
+.button.detail {
+    background-color: rgb(204, 173, 209);
 }
 
-.delete:hover {
+.button.detail:hover {
+    background-color: rgb(186, 153, 191) !important;
+}
+
+.button.delete {
+    background-color: #f08080;
+}
+
+.button.delete:hover {
     background-color: #e06666 !important;
 }
 

--- a/src/main/resources/templates/expenses/list.html
+++ b/src/main/resources/templates/expenses/list.html
@@ -13,6 +13,11 @@
     <div class="container">
     
     <h1>家計簿一覧</h1>
+    <br>
+    <a th:href="@{/expenses/new}"  class="button register">新しい支出を登録する</a> |
+        <a th:href="@{/expenses/calendar}" class="button primary">カレンダーで見る</a>
+        <br>
+        <br>
 
     <table border="1">
         <thead>
@@ -33,7 +38,7 @@
                 <td th:text="${expense.description}"></td>
                 <td>
                     <!-- 詳細リンク -->
-                    <a th:href="@{/expenses/{id}(id=${expense.id})}" class="button">詳細</a> |
+                    <a th:href="@{/expenses/{id}(id=${expense.id})}" class="button detail">詳細</a> |
                     <!-- 編集リンク -->
                     <a th:href="@{/expenses/edit/{id}(id=${expense.id})}" class="button">編集</a> |
                     <!-- 削除リンク -->
@@ -48,11 +53,6 @@
             </tr>
         </tbody>
     </table>
-
-    <br>
-
-    <a th:href="@{/expenses/new}"  class="button">新しい支出を登録する</a> |
-    <a th:href="@{/expenses/calendar}" class="button">カレンダーで見る</a>
     
     </div>
     


### PR DESCRIPTION
- ボタンに primary, detail, delete クラスを追加して色を明確に分けた
- 「新しい支出を登録」「カレンダーで見る」の位置とスタイルを調整