### PR TITLE
日別支出機能の追加とUI改善（CRUD操作・スタイル統一）

### DIFF
--- a/src/main/java/com/ozeken/expensecalendar/config/SecurityConfig.java
+++ b/src/main/java/com/ozeken/expensecalendar/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
             .formLogin(form -> form
                 .loginPage("/login")
                 //すべてのユーザーに"/expenses"にリダイレクト
-                .defaultSuccessUrl("/expenses", true)
+                .defaultSuccessUrl("/expenses/calendar", true)
                 //ログイン失敗時のリダイレクト先
                 .failureUrl("/login?error=true")
                 .permitAll()

--- a/src/main/java/com/ozeken/expensecalendar/controller/CalendarViewController.java
+++ b/src/main/java/com/ozeken/expensecalendar/controller/CalendarViewController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.ozeken.expensecalendar.dto.DailyTotal;
-import com.ozeken.expensecalendar.dto.ExpenseWithGenre;
 import com.ozeken.expensecalendar.entity.LoginUser;
 import com.ozeken.expensecalendar.service.ExpenseService;
 
@@ -86,35 +85,4 @@ public class CalendarViewController {
         return "expenses/calendar";
     }
     
-    /**
-     * 指定年月日（1日分）の支出一覧（ジャンル名付き）を表示します。
-     *
-     * @param year 年
-     * @param month 月
-     * @param day 日
-     * @param loginUser ログインユーザー情報
-     * @param model モデル
-     * @return 詳細表示テンプレート
-     */
-    @GetMapping("/day")
-    public String showExpensesByDay(@RequestParam int year,
-                                     @RequestParam int month,
-                                     @RequestParam int day,
-                                     @AuthenticationPrincipal LoginUser loginUser,
-                                     Model model) {
-        if (loginUser.getAppUser() == null) {
-            return "redirect:/login";
-        }
-
-        Long userId = loginUser.getAppUser().getId();
-        List<ExpenseWithGenre> expenses = expenseService.findWithGenreByDay(userId, year, month, day);
-
-        model.addAttribute("expenses", expenses);
-        model.addAttribute("year", year);
-        model.addAttribute("month", month);
-        model.addAttribute("day", day);
-
-        return "expenses/day";
-    }
-
 }

--- a/src/main/java/com/ozeken/expensecalendar/controller/DayExpenseController.java
+++ b/src/main/java/com/ozeken/expensecalendar/controller/DayExpenseController.java
@@ -1,0 +1,240 @@
+package com.ozeken.expensecalendar.controller;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import jakarta.validation.Valid;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.ozeken.expensecalendar.dto.ExpenseWithGenre;
+import com.ozeken.expensecalendar.entity.Expense;
+import com.ozeken.expensecalendar.entity.LoginUser;
+import com.ozeken.expensecalendar.form.ExpenseForm;
+import com.ozeken.expensecalendar.helper.ExpenseHelper;
+import com.ozeken.expensecalendar.service.ExpenseService;
+
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequestMapping("/expenses/day")
+@RequiredArgsConstructor
+public class DayExpenseController{
+	
+	/** DI */
+	private final ExpenseService expenseService;
+
+    /**
+     * 指定年月日（1日分）の支出一覧（ジャンル名付き）を表示
+     *
+     * @param year 年
+     * @param month 月
+     * @param day 日
+     * @param loginUser ログインユーザー情報
+     * @param model モデル
+     * @return 詳細表示テンプレート
+     */
+    @GetMapping
+    public String showExpensesByDay(
+    		@RequestParam int year,
+    		@RequestParam int month,
+    		@RequestParam int day,
+    		@AuthenticationPrincipal LoginUser loginUser,
+    		Model model) {
+        if (loginUser.getAppUser() == null) {
+            return "redirect:/login";
+        }
+
+        Long userId = loginUser.getAppUser().getId();
+        List<ExpenseWithGenre> expenses = expenseService.findWithGenreByDay(userId, year, month, day);
+
+        model.addAttribute("expenses", expenses);
+        model.addAttribute("year", year);
+        model.addAttribute("month", month);
+        model.addAttribute("day", day);
+
+        return "expenses/day";
+    }
+    
+    	/**
+    	 * 新規登録フォーム表示
+    	 * 
+    	 * @param year 年
+    	 * @param month 月
+    	 * @param day 日
+    	 * @param model モデル
+    	 * @return 新規登録フォーム
+    	 */
+	@GetMapping("/new")
+	public String showCreateFormByDay (
+			@RequestParam int year,
+			@RequestParam int month,
+			@RequestParam int day,
+			Model model ) {
+		
+		ExpenseForm form = new ExpenseForm();
+		form.setDate(LocalDate.of(year, month, day));
+		String returnUrl = String.format("/expenses/day?year=%d&month=%d&day=%d", year, month, day);
+	    
+		model.addAttribute("expenseForm",form);
+		model.addAttribute("postUrl", "/expenses/day");
+		model.addAttribute("returnUrl", returnUrl);
+		
+		return "expenses/form";
+	}
+	
+	/** 
+	 * 編集フォーム表示
+	 * 
+	 * @param id 支出ID
+	 * @param year 年
+	 * @param month 月
+	 * @param day 日
+	 * @param model モデル
+	 * @return 編集フォーム
+	 */
+	@GetMapping("/edit/{id}")
+	public String showUpdateFormByDay (
+			@PathVariable("id") Long id,
+			@RequestParam int year,
+			@RequestParam int month,
+			@RequestParam int day,
+			Model model,
+			@AuthenticationPrincipal LoginUser loginUser) {
+		
+		Long userId = loginUser.getAppUser().getId();
+		Expense expense = expenseService.findById(id, userId);
+		
+		if (expense==null) {
+			model.addAttribute("year", year);
+			model.addAttribute("month", month);
+			model.addAttribute("day", day);
+			
+			return "redirect:expenses/day";
+		}
+		ExpenseForm expenseForm = ExpenseHelper.convertToExpenseForm(expense);
+		String returnUrl = String.format("/expenses/day?year=%d&month=%d&day=%d", year, month, day);
+		
+		model.addAttribute("expenseForm", expenseForm);
+		model.addAttribute("postUrl", "/expenses/day");
+		model.addAttribute("returnUrl", returnUrl);
+		return "expenses/form";
+	}
+	/**
+	 * 詳細表示
+	 * 
+	 * @param id 支出ID
+	 * @param model モデル
+	 * @param loginUser ログインユーザー
+	 * 
+	 * @return 詳細表示画面
+	 */
+	@GetMapping("/{id}")
+	public String showExpenseDetailByDay (
+			@PathVariable("id") Long id,
+			@RequestParam int year,
+			@RequestParam int month,
+			@RequestParam int day,
+			Model model,
+			@AuthenticationPrincipal LoginUser loginUser) {
+		
+		Long userId = loginUser.getAppUser().getId();
+		ExpenseWithGenre expense = expenseService.findByIdWithGenre(id, userId);
+		
+		String returnUrl = String.format("/expenses/day?year=%d&month=%d&day=%d", year, month, day);
+		
+		model.addAttribute("expense", expense);
+		model.addAttribute("year", year);
+		model.addAttribute("month", month);
+		model.addAttribute("day", day);
+		model.addAttribute("returnUrl", returnUrl);
+		
+		return "expenses/detail";
+	}
+	
+	/**
+	 * 
+	 * 登録または更新処理
+	 * 
+	 * @param form フォーム
+	 * @param result バインディング結果
+	 * @param model モデル
+	 * @param loginUser ログインユーザー
+	 * 
+	 * @return リダイレクト先URL
+	 */
+	@PostMapping
+	public String saveOrUpdateExpenseByDay (
+	        @Valid @ModelAttribute ExpenseForm expenseForm,
+	        BindingResult result,
+	        Model model,
+	        @AuthenticationPrincipal LoginUser loginUser) {
+
+		// フォームから日付を取得
+	    LocalDate date = expenseForm.getDate();
+	    int year = date.getYear();
+	    int month = date.getMonthValue();
+	    int day = date.getDayOfMonth();
+	    // リダイレクト先URLを生成
+	    String returnUrl = String.format("/expenses/day?year=%d&month=%d&day=%d", year, month, day);
+
+	    if (result.hasErrors()) {
+	        model.addAttribute("expenseForm", expenseForm);
+	        model.addAttribute("postUrl", "/expenses/day");
+	        model.addAttribute("returnUrl", returnUrl);
+	        return "expenses/form";
+	    }
+
+	    Long userId = loginUser.getAppUser().getId();
+	    expenseForm.setUserId(userId);
+	    Expense expense = ExpenseHelper.convertToExpense(expenseForm);
+
+	    if (expense.getId() == null) {
+	        expenseService.insert(expense);
+	    } else {
+	        expenseService.update(expense);
+	    }
+
+	    return "redirect:" + returnUrl;
+	}
+	
+	/**
+	 * 削除処理
+	 * 
+	 * @param id 支出ID
+	 * @param year 年
+	 * @param month 月
+	 * @param day 日
+	 * @param model モデル
+	 * @param loginUser ログインユーザー
+	 * 
+	 * @return リダイレクト先URL
+	 */
+	@GetMapping("/delete/{id}")
+	public String deleteExpenseByDay (
+			@PathVariable("id") Long id,
+			@RequestParam int year,
+			@RequestParam int month,
+			@RequestParam int day,
+			Model model,
+			@AuthenticationPrincipal LoginUser loginUser) {
+		
+		Long userId = loginUser.getAppUser().getId();
+		expenseService.delete(id, userId);
+		
+		String returnUrl = String.format("/expenses/day?year=%d&month=%d&day=%d", year, month, day);
+		
+		return "redirect:" + returnUrl;
+	}
+	
+	
+}

--- a/src/main/java/com/ozeken/expensecalendar/controller/ExpenseController.java
+++ b/src/main/java/com/ozeken/expensecalendar/controller/ExpenseController.java
@@ -45,6 +45,9 @@ public class ExpenseController {
 	@GetMapping("/new")
 	public String showCreateForm(Model model) {
 		model.addAttribute("expenseForm", new ExpenseForm());
+		model.addAttribute("postUrl", "/expenses");
+		model.addAttribute("returnUrl", "/expenses");
+		
 		return "expenses/form";
 	}
 
@@ -59,6 +62,8 @@ public class ExpenseController {
 		}
 		ExpenseForm expenseForm = ExpenseHelper.convertToExpenseForm(expense);
 		model.addAttribute("expenseForm", expenseForm);
+		model.addAttribute("postUrl", "/expenses");
+		model.addAttribute("returnUrl", "/expenses");
 		return "expenses/form";
 	}
 		
@@ -69,6 +74,7 @@ public class ExpenseController {
 	    Long userId = loginUser.getAppUser().getId();
 	    ExpenseWithGenre expense = expenseService.findByIdWithGenre(id, userId);
 	    model.addAttribute("expense", expense);
+	    model.addAttribute("returnUrl", "/expenses");
 	    return "expenses/detail";
 	}
 
@@ -82,6 +88,8 @@ public class ExpenseController {
 		
 		if (result.hasErrors()) {
 			model.addAttribute("expenseForm", expenseForm);
+			model.addAttribute("postUrl", "/expenses");
+			model.addAttribute("returnUrl", "/expenses");
 			return "expenses/form";
 		}
 

--- a/src/main/resources/static/css/base.css
+++ b/src/main/resources/static/css/base.css
@@ -70,12 +70,15 @@ a.button {
     display: inline-block;
 }
 
-.button.primary {
+.button.primary,
+.return-button.primary {
     background-color: #ffb347;
     color: white;
 }
 
-.button.primary:hover {
+
+.button.primary:hover,
+.return-button.primary:hover {
     background-color: #ff9f00;
 }
 
@@ -103,6 +106,10 @@ button.login:hover,
 .return-button:hover {
     border-color: #5cc1bc;
     text-decoration: underline;
+}
+
+.register {
+    background-color: lightgreen !important;
 }
 
 /* 戻るボタン */

--- a/src/main/resources/static/css/calendar.css
+++ b/src/main/resources/static/css/calendar.css
@@ -35,9 +35,9 @@ td.empty {
 
 .calendar-instruction {
     font-size: 1.2em;
-    background-color: aliceblue;
+    background-color: orangered;
     font-weight: bold;
-    color: #333;
+    color: #f0f0f0;
     margin-top: 20px;
     margin-bottom: 10px;
     text-align: center;

--- a/src/main/resources/templates/expenses/calendar.html
+++ b/src/main/resources/templates/expenses/calendar.html
@@ -12,14 +12,15 @@
     <h1 th:text="${year} + '年' + ${month} + '月の家計簿'"></h1>
     <br>
     <div>
-    <a th:href="@{/expenses}" class="button">一覧に戻る</a>
+    <a th:href="@{/expenses}" class="button primary">一覧へ</a> |
+    <a th:href="@{/expenses/new}"  class="button register">新しい支出を登録する</a>
     <div>
     <div class="calendar-controls">
         <a th:href="@{/expenses/calendar(year=${prevYear}, month=${prevMonth})}" class="button">← 前の月</a>
         <a th:href="@{/expenses/calendar(year=${nextYear}, month=${nextMonth})}" class="button">次の月 →</a>
     </div>
     
-    <h2 class="calendar-instruction">◎日にちをクリックで支出リストを表示</h2>
+    <h2 class="calendar-instruction">⇩ ◎日にちをクリックその日の支出一覧を表示 ⇩</h2>
     <br>
 
 
@@ -54,7 +55,7 @@
 
                     <!-- 日付と支出 -->
                     <div th:if="${cellIndex >= firstDayOfWeek and dateNum <= daysInMonth}">
-                        <a th:href="@{/expenses/calendar/day(year=${year}, month=${month}, day=${dateNum})}"
+                        <a th:href="@{/expenses/day(year=${year}, month=${month}, day=${dateNum})}"
                                th:text="${dateNum}"
                                class="calendar-date-link">
                             </a><br>
@@ -63,7 +64,7 @@
                         <!-- 合計金額の表示 -->
                         <span th:each="dailyTotal : ${dailyTotals}"
                               th:if="${dailyTotal.day == (dateNum)}"
-                              th:text="'支出: ￥' + ${dailyTotal.total}"
+                              th:text="'支出: ￥' + ${#numbers.formatInteger({dailyTotal.total},0,'COMMA')}"
                               class="total-amount">
                           </span>
                         

--- a/src/main/resources/templates/expenses/day.html
+++ b/src/main/resources/templates/expenses/day.html
@@ -12,6 +12,10 @@
     <div class="container">
 
     <h1 th:text="${year} + '年' + ${month} + '月' + ${day} + '日の支出一覧'">yyyy年mm月dd日の支出一覧</h1>
+    <br>
+        <a th:href="@{/expenses/day/new(year=${year}, month=${month}, day=${day})}"  class="button register">新しい支出を登録する</a>
+            <br>
+            <br>
 
     <table border="1">
         <thead>
@@ -19,17 +23,35 @@
                 <th>ジャンル</th>
                 <th>金額</th>
                 <th>メモ</th>
+                <th>操作</th>
             </tr>
         </thead>
         <tbody>
             <tr th:each="expense : ${expenses}">
                 <td th:text="${expense.genreName}">食費</td>
-                <td th:text="'￥' + ${expense.amount}">￥1000</td>
+                <td th:text="'￥' + ${#numbers.formatInteger(expense.amount, 0, 'COMMA')}">￥1,000</td>
                 <td th:text="${expense.description}">ランチ</td>
+                <td>
+                    <!-- 詳細リンク -->
+                    <a th:href="@{'/expenses/day/'+${expense.id}+
+                                  '?year='+${year}+'&month='+${month}+'&day='+${day}}"
+                       class="button detail">詳細</a> |
+
+                    <!-- 編集リンク -->
+                    <a th:href="@{'/expenses/day/edit/'+${expense.id}+
+                                  '?year='+${year}+'&month='+${month}+'&day='+${day}}"
+                       class="button">編集</a> |
+                    <!-- 削除リンク -->
+                    <a th:href="@{'/expenses/day/delete/'+${expense.id}+
+                                  '?year=' + ${year} + '&month='+${month}+'&day='+${day}}"
+                       onclick="return confirm('本当に削除しますか？');"
+                       class="button delete">削除</a>
+
+                </td>
             </tr>
             
             <tr th:if="${#lists.isEmpty(expenses)}">
-                           <td colspan="3" class="no-data">データはありません</td>
+                           <td colspan="4" class="no-data">データはありません</td>
             </tr>
             
         </tbody>
@@ -37,7 +59,7 @@
     
     <br>
     
-        <a th:href="@{/expenses/calendar(year=${year}, month=${month})}" class="button">← カレンダーに戻る</a>
+        <a th:href="@{/expenses/calendar(year=${year}, month=${month})}" class="button primary">← カレンダーに戻る</a>
     
     </div>
 

--- a/src/main/resources/templates/expenses/detail.html
+++ b/src/main/resources/templates/expenses/detail.html
@@ -21,7 +21,7 @@
         </tr>
         <tr>
             <th>金額</th>
-            <td th:text="${expense.amount}"></td>
+            <td th:text="'¥' + ${#numbers.formatInteger(expense.amount, 0, 'COMMA')}">¥1,000</td>
         </tr>
         <tr>
             <th>説明</th>
@@ -32,7 +32,7 @@
     <br>
 
     <div class="return-wrapper">
-    <a th:href="@{/expenses}" class="return-button">一覧に戻る</a>
+    <a th:href="${returnUrl}" class="return-button">一覧に戻る</a>
     </div>
 </body>
 </html>

--- a/src/main/resources/templates/expenses/form.html
+++ b/src/main/resources/templates/expenses/form.html
@@ -11,7 +11,7 @@
     <h1 th:text="${expenseForm.id} != null ? '支出の編集' : '支出の登録'"></h1>
 
     <!-- フォーム開始 -->
-    <form th:action="@{/expenses}" th:object="${expenseForm}" method="post">
+    <form th:action="@{${postUrl}}" th:object="${expenseForm}" method="post">
         
 
          <!-- hiddenのid（編集時用） -->
@@ -52,7 +52,7 @@
 
         <!-- 送信ボタン -->
         <div class="form-group">
-            <button type="submit" th:text="${expenseForm.id} != null ? '更新' : '登録'"></button>
+            <button type="submit" th:text="${expenseForm.id} != null ? '更新' : '登録'" class="button register"></button>
         </div>
 
     </form>
@@ -61,7 +61,7 @@
 
     <!-- 一覧に戻るリンク -->
     <div class="return-wrapper" >
-    <a th:href="@{/expenses}" class="return-button">一覧に戻る</a>
+        <a th:href="@{${returnUrl}}" class="return-button">一覧に戻る</a>
     </div>
 
 </body>

--- a/src/main/resources/templates/expenses/list.html
+++ b/src/main/resources/templates/expenses/list.html
@@ -14,8 +14,8 @@
     
     <h1>家計簿一覧</h1>
     <br>
-    <a th:href="@{/expenses/new}"  class="button register">新しい支出を登録する</a> |
-        <a th:href="@{/expenses/calendar}" class="button primary">カレンダーで見る</a>
+    <a th:href="@{/expenses/calendar}" class="button primary">← カレンダーに戻る</a> |
+    <a th:href="@{/expenses/new}"  class="button register">新しい支出を登録する</a>
         <br>
         <br>
 
@@ -34,7 +34,7 @@
             <tr th:each="expense : ${expenses}">
                 <td th:text="${expense.date}"></td>
                 <td th:text="${expense.genreName}"></td>
-                <td th:text="${expense.amount}"></td>
+                <td th:text="'¥' + ${#numbers.formatInteger(expense.amount, 0, 'COMMA')}">¥1,000</td>
                 <td th:text="${expense.description}"></td>
                 <td>
                     <!-- 詳細リンク -->

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -15,7 +15,7 @@
         <h1>家計簿アプリを始めましょう！</h1>
         <br>
         <nav>
-            <a th:href="@{/register}" class="button">新規登録</a> |
+            <a th:href="@{/register}" class="button register">新規登録</a> |
             <a th:href="@{/login}" class="login">ログイン</a>
         </nav>
     </header>
@@ -41,7 +41,7 @@
 
         <section>
             <h2>まずは新規登録</h2>
-            <a th:href="@{/register}" class="button">新規登録</a>
+            <a th:href="@{/register}" class="button register">新規登録</a>
         </section>
     </main>
 

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -48,7 +48,7 @@
     </div>
 
     <div class="return-wrapper">
-        <p>アカウントをお持ちでない方は<a th:href="@{/register}" class="button">ユーザー登録</a>へ</p>
+        <p>アカウントをお持ちでない方は<a th:href="@{/register}" class="button register">ユーザー登録</a>へ</p>
         <br>
         <a th:href="@{/}" class="return-button">トップに戻る</a>
     </div>

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -29,7 +29,7 @@
         <br>
         
         <div class="form-group">
-        <button type="submit" value="登録" class="button">登録</button>
+        <button type="submit" value="登録" class="button register">登録</button>
         </div>
         
     </form>


### PR DESCRIPTION
## 概要
日別支出のCRUD操作に対応した機能と、各画面におけるUIの改善を実施しました。

## 主な変更内容

### 機能追加（Controller）
- `DayExpenseController` を新規追加し、日別の支出一覧表示、登録、編集、削除、詳細表示に対応
- `CalendarViewController` から日別表示機能を移動
- `ExpenseController` に `postUrl` および `returnUrl` を導入し、フォーム再利用に対応

### UI改善（HTML/CSS）
- 金額の表示をカンマ区切りに統一（`#numbers.formatInteger`）
- 各画面のボタンに `.primary` / `.register` クラスを追加し、視認性を向上
- カレンダー上部の案内文の背景色を強調
- 「戻る」「登録する」などのリンクを context-aware に改善（戻り先を保持）

### その他
- ログイン後のデフォルト遷移先を `/expenses` → `/expenses/calendar` に変更