### PR TITLE
fix: usersテーブルの初期データ挿入でID指定を削除

### DIFF
--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,10 +1,10 @@
 -- ユーザーデータの挿入
-INSERT INTO users (id, username, password, role)
+INSERT INTO users (username, password, role)
 VALUES 
-(1,'user1','$2a$10$er93XnfZ3P62/.KRbXLrf.9wdZaIO35n6sQHHdB6jhrGCqqX0sb0u', 'USER'),
-(2,'user2','$2a$10$OtijxZbUIfomg8p3w0gDyey50F6I41elanLP.tiC.vqp2l2BQa6TW', 'USER'),
-(3,'user3','$2a$10$aCOrvlmjb9R7u6hjAbw8O.ht3mRLBVcjJfPdGjLlA2duKdrANMMBG', 'USER'),
-(4,'demo','$2a$10$RS0fMETMlv1BGx2Vno73XOO6J8qPha05LgrkB2.AmSLrtSWhB8ex6', 'USER')
+('user1','$2a$10$er93XnfZ3P62/.KRbXLrf.9wdZaIO35n6sQHHdB6jhrGCqqX0sb0u', 'USER'),
+('user2','$2a$10$OtijxZbUIfomg8p3w0gDyey50F6I41elanLP.tiC.vqp2l2BQa6TW', 'USER'),
+('user3','$2a$10$aCOrvlmjb9R7u6hjAbw8O.ht3mRLBVcjJfPdGjLlA2duKdrANMMBG', 'USER'),
+('demo','$2a$10$RS0fMETMlv1BGx2Vno73XOO6J8qPha05LgrkB2.AmSLrtSWhB8ex6', 'USER')
 ON CONFLICT (username) DO NOTHING;
 
 --ジャンルデータの挿入


### PR DESCRIPTION
- IDを手動で指定していたINSERT文を、自動採番に変更
- 既存の ON CONFLICT 句はそのまま活用