### PR TITLE
Docker環境整備：build構成修正・初期データ調整・devプロファイル追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,11 +43,6 @@ Thumbs.db
 # Log files
 *.log
 
-# Spring Boot personal config
-# 本番以外の application-*.properties を無視
-src/main/resources/application-*.properties
-!src/main/resources/application-prod.properties
-
 # Docker files (optional)
 *.env
 docker-compose.override.yml

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,8 +4,8 @@ FROM eclipse-temurin:17-jdk AS build
 WORKDIR /app
 
 # 依存関係をキャッシュするためにビルドに必要なファイルを先にコピー
-COPY build.gradle settings.gradle gradlew gradlew.bat ./  
-COPY gradle ./gradle
+COPY backend/build.gradle backend/settings.gradle backend/gradlew backend/gradlew.bat ./
+COPY backend/gradle ./gradle
 
 # gradlewに実行権限を付与（Linux環境なら必須）
 RUN chmod +x gradlew

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -1,0 +1,27 @@
+#== ローカル開発環境の設定 ==
+
+#Postgresのドライバの設定
+spring.datasource.driver-class-name=org.postgresql.Driver
+#PostgresのURLの設定
+spring.datasource.url=${SPRING_DATASOURCE_URL}
+#Postgresのユーザ名の設定
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
+#Postgresのパスワードの設定
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
+
+#SQLスクリプトの初期化の設定
+spring.sql.init.mode=always
+spring.sql.init.schema-locations=classpath:schema.sql
+spring.sql.init.data-locations=classpath:data.sql
+
+#Log表示設定
+logging.level.com.ozeken.expensecalendar=DEBUG
+
+# MyBatisのマッパーXMLの場所を指定
+mybatis.mapper-locations=classpath:mapper/*.xml
+# MyBatisで使うエンティティのパッケージ指定
+mybatis.type-aliases-package=com.ozeken.expensecalendar.entity
+
+# Thymeleafのキャッシュを無効にする
+spring.thymeleaf.cache=false
+

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -1,10 +1,10 @@
 -- ユーザーデータの挿入
-INSERT INTO users (id, username, password, role)
+INSERT INTO users (username, password, role)
 VALUES 
-(1,'user1','$2a$10$er93XnfZ3P62/.KRbXLrf.9wdZaIO35n6sQHHdB6jhrGCqqX0sb0u', 'USER'),
-(2,'user2','$2a$10$OtijxZbUIfomg8p3w0gDyey50F6I41elanLP.tiC.vqp2l2BQa6TW', 'USER'),
-(3,'user3','$2a$10$aCOrvlmjb9R7u6hjAbw8O.ht3mRLBVcjJfPdGjLlA2duKdrANMMBG', 'USER'),
-(4,'demo','$2a$10$RS0fMETMlv1BGx2Vno73XOO6J8qPha05LgrkB2.AmSLrtSWhB8ex6', 'USER')
+('user1','$2a$10$er93XnfZ3P62/.KRbXLrf.9wdZaIO35n6sQHHdB6jhrGCqqX0sb0u', 'USER'),
+('user2','$2a$10$OtijxZbUIfomg8p3w0gDyey50F6I41elanLP.tiC.vqp2l2BQa6TW', 'USER'),
+('user3','$2a$10$aCOrvlmjb9R7u6hjAbw8O.ht3mRLBVcjJfPdGjLlA2duKdrANMMBG', 'USER'),
+('demo','$2a$10$RS0fMETMlv1BGx2Vno73XOO6J8qPha05LgrkB2.AmSLrtSWhB8ex6', 'USER')
 ON CONFLICT (username) DO NOTHING;
 
 --ジャンルデータの挿入

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,7 +3,8 @@ version: "3.9"
 services:
   backend:
     build:
-      context: ./backend
+      context: .
+      dockerfile: backend/Dockerfile
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
refactor: Dockerfileとcompose.yamlのビルド構成を調整
- Dockerfileのビルドコンテキストをプロジェクトルートに変更し、必要ファイルのパスも修正
- compose.yaml内のbuild設定をcontext: . に変更し、dockerfileパスを明示

fix: ユーザー挿入時のID指定を削除してON CONFLICTに対応
- usersテーブルへの初期データ挿入時にidを省略し、自動採番に対応
- username重複時のエラーを防ぐため、ON CONFLICT句を維持

feat: application-dev.propertiesを公開し、プレースホルダに対応
- application-dev.propertiesをGit管理下に追加
- プレースホルダー（${...}）を用いて環境変数で認証情報などを外部化
- .gitignoreの設定を調整し、従来除外されていた開発用プロファイルを管理対象に変更