### PR TITLE
fix: タイプミスのsetting.gradleファイルを削除

### DIFF
--- a/setting.gradle
+++ b/setting.gradle
@@ -1,2 +1,0 @@
-rootProject.name = 'expensecalendar'
-includeBuild 'backend'


### PR DESCRIPTION
- タイプミスのsetting.gradleと正しい名前のsettings.gradleが存在していたため、 settings.gradleのみ残しました