### PR TITLE
rootのsetting.gradleのtaskの削除と変更, READMEの変更とProcfileの削除

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: java -Dserver.port=$PORT -jar build/libs/expensecalendar-0.0.1-SNAPSHOT.jar

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 
 以下のサービスでデプロイ済みです。
 
-- Heroku: [https://expense-calendar-app-6a9c24a693ce.herokuapp.com/](https://expense-calendar-app-6a9c24a693ce.herokuapp.com/)
 - Railway: [https://expensecalendar-production.up.railway.app/](https://expensecalendar-production.up.railway.app/)
 
 ## 主な機能
@@ -32,7 +31,7 @@
 | データベース | PostgreSQL                    |
 | ORM        | MyBatis                        |
 | ビルド     | Gradle / Docker                        |
-| デプロイ   | Heroku / Railway   |
+| デプロイ   | Railway   |
 
 ## ER図
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,16 +24,9 @@ tasks.register("test") {
     dependsOn gradle.includedBuild("backend").task(":test")
 }
 
-// テストなしでの高速ビルド（compileタスクのみ実行）
+// テストなしでの実行可能JARファイル作成（ローカル, railway用）
 tasks.register("build") {
     group = "build"
     description = "Builds backend application without tests"
-    dependsOn("compile")
-}
-
-// Heroku等のデプロイプラットフォーム用
-tasks.register("stage") {
-    group = "build"
-    description = "Prepares application for deployment"
-    dependsOn("build")
+    dependsOn gradle.includedBuild("backend").task(":bootJar")
 }


### PR DESCRIPTION
fix: rootのsetting.gradleのtaskの削除と変更
変更したもの
- build: `compile`するのみでJarファイルが生成されなかったため`bootJar`に変更
削除したもの
- staged: デプロイを`Railway`のみにしたため削除

docs: READMEの変更とProcfileの削除
- デプロイを`Reilway`のみにしたためREADMEの変更とProcfileの削除