### PR TITLE
feat: RailwayからHerokuへのデプロイ環境移行

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: cd backend && java -Dserver.port=$PORT -jar build/libs/expensecalendar-0.0.1-SNAPSHOT.jar

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 以下のサービスでデプロイ済みです。
 
-- Railway: [https://expensecalendar-production.up.railway.app/](https://expensecalendar-production.up.railway.app/)
+- Heroku: [https://expense-calendar-app-6a9c24a693ce.herokuapp.com/](https://expense-calendar-app-6a9c24a693ce.herokuapp.com/)
 
 ## 主な機能
 
@@ -31,7 +31,7 @@
 | データベース | PostgreSQL                    |
 | ORM        | MyBatis                        |
 | ビルド     | Gradle / Docker                        |
-| デプロイ   | Railway   |
+| デプロイ   | Heroku   |
 
 ## ER図
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,16 +24,23 @@ tasks.register("test") {
     dependsOn gradle.includedBuild("backend").task(":test")
 }
 
-// コード品質チェック（静的解析等, Railway用）
+// コード品質チェック（静的解析等）
 tasks.register("check") {
     group = "verification"
     description = "Runs all verification tasks"
     dependsOn gradle.includedBuild("backend").task(":check")
 }
 
-// テストなしでの実行可能JARファイル作成（ローカル, Railway用）
+// テストなしでの実行可能JARファイル作成（ローカル）
 tasks.register("build") {
     group = "build"
     description = "Builds backend application without tests"
     dependsOn gradle.includedBuild("backend").task(":bootJar")
+}
+
+// Heroku等のデプロイプラットフォーム用
+tasks.register("stage") {
+    group = "build"
+    description = "Prepares application for deployment"
+    dependsOn("build")
 }

--- a/railway.toml
+++ b/railway.toml
@@ -1,6 +1,0 @@
-[build]
-builder = "nixpacks"
-buildCommand = "cd backend && ./gradlew build --no-daemon"
-
-[deploy]
-startCommand = "cd backend && java -jar build/libs/*.jar"


### PR DESCRIPTION
feat: RailwayはローカルのDockerと相性が悪いためHerokuへのデプロイ環境移行
- Herokuデプロイ用のProcfileを追加
- Railway固有の設定ファイル（railway.toml）を削除
- 動的ポート対応でSpring Bootアプリケーションを起動するよう設定"

build: Herokuデプロイサポートの追加
- Herokuのための`stage`タスクを追加
- タスク説明からRailway固有の記述を削除

docs: Heroku移行に伴うデプロイ情報の更新
- RailwayのURLをHerokuデプロイURLに変更