### PR TITLE
chore: 非推奨のversion: 指定を削除

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   expensecalendar-backend:
     build:


### PR DESCRIPTION
- composeは`version`を自動で読み取るので、削除しました