### PR TITLE
fix: heroku用のstageタスクを再度追加

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,1 +1,6 @@
-// Root build.gradle（Multi-Project Build 用。明示的なタスク定義はここでは行っていない）
+// Heroku等のデプロイプラットフォーム用
+tasks.register("stage") {
+    group = "build"
+    description = "Prepares application for deployment"
+    dependsOn("expensecalendar-backend:bootJar")
+}


### PR DESCRIPTION
- herokuは`stage`タスクが必要なためmultiproject形式にしてgradleファイルに再度追加