### PR TITLE
refactor: JPA依存の整理とテストプロファイル設定の追加

### DIFF
--- a/expensecalendar-backend/build.gradle
+++ b/expensecalendar-backend/build.gradle
@@ -23,13 +23,12 @@ repositories {
 	mavenCentral()
 }
 
-dependencies {
-  implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-  implementation 'org.springframework.boot:spring-boot-starter-security'
+dependencies {	
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.postgresql:postgresql'
@@ -43,4 +42,5 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+    systemProperty "spring.profiles.active", "test"
 }

--- a/expensecalendar-backend/src/main/java/com/ozeken/expensecalendar/entity/AppUser.java
+++ b/expensecalendar-backend/src/main/java/com/ozeken/expensecalendar/entity/AppUser.java
@@ -1,22 +1,19 @@
 package com.ozeken.expensecalendar.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-
 import lombok.Data;
 
 @Data
-@Entity
 public class AppUser {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+	// ID
     private Long id;
 
-    
+    // ユーザー名
     private String username;
+    
+    // パスワード
     private String password;
+    
+    // 権限
     private String role; // "USER" や "ADMIN"
 }

--- a/expensecalendar-backend/src/test/java/com/ozeken/expensecalendar/ExpensecalendarApplicationTests.java
+++ b/expensecalendar-backend/src/test/java/com/ozeken/expensecalendar/ExpensecalendarApplicationTests.java
@@ -2,10 +2,8 @@ package com.ozeken.expensecalendar;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles("test")
 class ExpensecalendarApplicationTests {
 
 	@Test

--- a/expensecalendar-backend/src/test/java/com/ozeken/expensecalendar/controller/CalendarViewControllerTest.java
+++ b/expensecalendar-backend/src/test/java/com/ozeken/expensecalendar/controller/CalendarViewControllerTest.java
@@ -14,7 +14,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.ozeken.expensecalendar.entity.AppUser;
@@ -22,7 +21,6 @@ import com.ozeken.expensecalendar.entity.LoginUser;
 import com.ozeken.expensecalendar.service.ExpenseService;
 
 @WebMvcTest(CalendarViewController.class)
-@ActiveProfiles("test")
 class CalendarViewControllerTest {
 
     @Autowired

--- a/expensecalendar-backend/src/test/java/com/ozeken/expensecalendar/service/ExpenseServiceImplTest.java
+++ b/expensecalendar-backend/src/test/java/com/ozeken/expensecalendar/service/ExpenseServiceImplTest.java
@@ -8,14 +8,12 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
 import com.ozeken.expensecalendar.dto.ExpenseWithGenre;
 import com.ozeken.expensecalendar.entity.Expense;
 import com.ozeken.expensecalendar.service.impl.ExpenseServiceImpl;
 
 @SpringBootTest
-@ActiveProfiles("test")
 class ExpenseServiceImplTest {
 
 	@Autowired


### PR DESCRIPTION
#### 主な変更点
- JPA は MyBatis を使用しているため不要と判断し、依存を削除しました。
- テストプロファイルを追加し、Gradle 側で `spring.profiles.active=test` を設定しました。

#### その他
- `build.gradle` の依存順序を整理しました。
- インデント修正を一部行いました。

---

### refactor: AppUser クラスの JPA アノテーション削除とコメント追加

- `@Entity`, `@Id`, `@GeneratedValue` などを削除しました。
- 各フィールドに日本語コメントを追加し、意図を明確にしました。

---

### chore: テストクラスからの `@ActiveProfiles("test")` 削除

- `spring.profiles.active=test` を Gradle 側で一括設定することで、
  各テストクラスの `@ActiveProfiles("test")` アノテーションを削除しました。