### PR TITLE
feat: 支出一覧のページネーション取得処理を追加

### DIFF
--- a/expensecalendar-backend/src/main/java/com/ozeken/expensecalendar/controller/ExpenseController.java
+++ b/expensecalendar-backend/src/main/java/com/ozeken/expensecalendar/controller/ExpenseController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import com.ozeken.expensecalendar.dto.ExpenseWithGenre;
 import com.ozeken.expensecalendar.entity.Expense;
@@ -31,13 +32,19 @@ public class ExpenseController {
 	/** DI */
 	private final ExpenseService expenseService;
 
-	/** 家計簿一覧表示 */
+	/**
+	 *  家計簿一覧表示（ページネーション対応）
+	 */
 	@GetMapping
-	public String listExpenses(Model model, @AuthenticationPrincipal LoginUser loginUser) { 
-		
+	public String listExpenses(@RequestParam(name = "page", defaultValue = "1") int page,
+			                                 @RequestParam(name = "size", defaultValue = "20") int size,
+			                                 Model model, 
+			                                 @AuthenticationPrincipal LoginUser loginUser) { 
 		Long userId = loginUser.getAppUser().getId();
-		List<ExpenseWithGenre> expenses = expenseService.findAllWithGenre(userId);
+		List<ExpenseWithGenre> expenses = expenseService.findPagedExpensesByPage(userId, page, size);
 		model.addAttribute("expenses", expenses);
+		model.addAttribute("currentPage", page);
+		model.addAttribute("pageSize", size);
 		return "expenses/list";
 	}
 

--- a/expensecalendar-backend/src/main/java/com/ozeken/expensecalendar/mapper/ExpenseMapper.java
+++ b/expensecalendar-backend/src/main/java/com/ozeken/expensecalendar/mapper/ExpenseMapper.java
@@ -29,6 +29,20 @@ public interface ExpenseMapper {
     List<ExpenseWithGenre> selectWithGenreByUserId(@Param("userId") Long userId);
     
     /**
+     * 全期間の支出一覧をページネーションで取得（ジャンル名付き）
+     * 
+     * @param userId ユーザーID
+     * @param limit  取得する最大件数（1ページあたりの件数）
+     * @param offset 取得開始位置（例：0なら先頭から、10なら11件目から）
+     * @return 支出リスト（ジャンル名付き、ページネーション対応）
+     */
+    List<ExpenseWithGenre> selectWithGenreByUserIdPaged(
+    		@Param("userId") Long userId,
+    		@Param("limit") int limit,
+    		@Param("offset") int offset
+    		);
+    
+    /**
      * 指定年月日での支出一覧を取得（ジャンル名付き）
      *
      * @param userId ユーザーID

--- a/expensecalendar-backend/src/main/java/com/ozeken/expensecalendar/service/ExpenseService.java
+++ b/expensecalendar-backend/src/main/java/com/ozeken/expensecalendar/service/ExpenseService.java
@@ -25,6 +25,27 @@ public interface ExpenseService {
     List<ExpenseWithGenre> findAllWithGenre(Long userId);
     
     /**
+     * 全期間の支出一覧をページネーションで取得（ジャンル名付き）
+     * 
+     * @param userId ユーザーID
+     * @param limit  取得する最大件数（1ページあたりの件数）
+     * @param offset 取得開始位置（例：0なら先頭から、10なら11件目から）
+     * @return 支出リスト（ジャンル名付き、ページネーション対応）
+     */
+    List<ExpenseWithGenre> findPagedExpenses(Long userId, int limit, int offset);
+    
+    /**
+     * ページ番号とページサイズから支出一覧を取得（ページ番号は1から開始）
+     * 
+     * @param userId ユーザーID
+     * @param page  現在のページ番号（1から始まる）
+     * @param size 1ページあたりの表示件数
+     * @return 支出リスト（ジャンル名付き、ページネーション対応）
+     * 
+     */
+    List<ExpenseWithGenre> findPagedExpensesByPage(Long userId, int page, int size);
+    
+    /**
 	 * 指定ユーザーIDと年月日での支出リストを取得します（ジャンル名付き）
 	 *
 	 * @param userId ユーザーID

--- a/expensecalendar-backend/src/main/java/com/ozeken/expensecalendar/service/impl/ExpenseServiceImpl.java
+++ b/expensecalendar-backend/src/main/java/com/ozeken/expensecalendar/service/impl/ExpenseServiceImpl.java
@@ -22,9 +22,15 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 @RequiredArgsConstructor
 public class ExpenseServiceImpl implements ExpenseService {
+	
+	// --------- 定数 --------------------
+    // 支出一覧表示数のデフォルト
+    private static final int DEFAULT_PAGE_SIZE = 20;
 
-    // DI対象（データアクセス層）
+    
+    // ------------ DI対象 ---------------
     private final ExpenseMapper expenseMapper;
+    
 
     // ------- 取得処理 (リスト) -----------------------------------------
 
@@ -32,6 +38,29 @@ public class ExpenseServiceImpl implements ExpenseService {
     public List<ExpenseWithGenre> findAllWithGenre(Long userId) {
         return expenseMapper.selectWithGenreByUserId(userId);
     }
+    
+	@Override
+	public List<ExpenseWithGenre> findPagedExpenses(Long userId, int limit, int offset) {
+		
+		return expenseMapper.selectWithGenreByUserIdPaged(userId, limit, offset);
+	}
+	
+	/**
+	 * ページ番号とページサイズから支出一覧を取得（ページ番号は1から開始）
+	 */
+	@Override
+	public List<ExpenseWithGenre> findPagedExpensesByPage(Long userId, int page, int size) {
+		
+		if (page < 1 ) {
+			page = 1;
+		}
+		if (size < 1 ) {
+			size = DEFAULT_PAGE_SIZE;
+		}
+		// 例: page=1 -> offset=0（先頭から取得）
+		int offset = (page-1) * size;
+		return  findPagedExpenses(userId, size, offset);
+	}
     
     @Override
 	public List<ExpenseWithGenre> findWithGenreByDay(Long userId, int year, int month, int day) {

--- a/expensecalendar-backend/src/main/resources/mapper/ExpenseMapper.xml
+++ b/expensecalendar-backend/src/main/resources/mapper/ExpenseMapper.xml
@@ -35,6 +35,27 @@
   ORDER BY e.date DESC
 </select>
 
+<!-- 
+  指定されたユーザーIDに紐づく支出一覧を、ジャンル名付きでページネーション取得するSQL。
+  支出は日付の降順（新しい順）に並び、LIMIT/OFFSETで表示件数を制御する。
+  主に一覧画面（支出履歴ページ）での表示に使用される。
+-->
+<select id="selectWithGenreByUserIdPaged" resultMap="ExpenseWithGenreMap">
+  SELECT
+    e.id,
+    e.user_id,
+    e.date,
+    e.genre_id,
+    g.name AS genre_name,
+    e.amount,
+    e.description
+  FROM expenses e
+  JOIN genres g ON e.genre_id = g.id
+  WHERE e.user_id = #{userId}
+  ORDER BY e.date DESC
+  LIMIT #{limit} OFFSET #{offset}
+</select>
+
 <!-- IDで一件取得  -->
   <select id="selectByIdAndUserId" resultType="com.ozeken.expensecalendar.entity.Expense">
     SELECT id, user_id, date, genre_id, amount, description

--- a/expensecalendar-backend/src/main/resources/templates/expenses/list.html
+++ b/expensecalendar-backend/src/main/resources/templates/expenses/list.html
@@ -12,7 +12,7 @@
     
     <div class="container">
     
-    <h1>家計簿一覧</h1>
+    <h1>家計簿一覧（ページ: <span th:text="${currentPage}"></span>)</h1>
     <br>
     <a th:href="@{/expenses/calendar}" class="button primary">← カレンダーに戻る</a> |
     <a th:href="@{/expenses/new}"  class="button register">新しい支出を登録する</a>
@@ -54,6 +54,18 @@
         </tbody>
     </table>
     
+
+    <!--ページネーションリンク-->
+        <div>
+        <a th:href="@{/expenses?(page = ${currentPage - 1}, size = ${pageSize})}"
+              th:if="${currentPage > 1}">← 前へ</a>
+        
+        <span>ページ <span th:text="${currentPage}">1</span></span>
+
+        <a th:href="@{/expenses?(page = ${currentPage + 1}, size = ${pageSize})}"
+              th:if="${expenses.size() == pageSize}">次へ →</a>
+        </div>
+
     </div>
     
 </body>


### PR DESCRIPTION
## feat: 支出一覧のページネーション取得処理をxmlとmapperクラスに追加

---

## feat: 支出一覧のページネーション取得機能をServiceクラスに追加
- `findPagedExpenses`
mapperクラスと直接やり取り

- `findPagedExpensesByPage`
ページとデフォルトのサイズをセットし`findPagedExpenses`を返す

---

## feat: 家計簿一覧画面にページネーション機能を追加

    - `ExpenseController`
      - `page` / `size` パラメータを受け取り、Service呼び出しを変更

    - `list.html`
      - 「前へ」「次へ」のリンクを追加
      - 現在のページ番号を表示