### PR TITLE
test: @ActiveProfiles("test") 追加し、ExpenseServiceImplTestをリファクタ

### DIFF
--- a/expensecalendar-backend/src/test/java/com/ozeken/expensecalendar/ExpensecalendarApplicationTests.java
+++ b/expensecalendar-backend/src/test/java/com/ozeken/expensecalendar/ExpensecalendarApplicationTests.java
@@ -2,8 +2,10 @@ package com.ozeken.expensecalendar;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class ExpensecalendarApplicationTests {
 
 	@Test

--- a/expensecalendar-backend/src/test/java/com/ozeken/expensecalendar/controller/CalendarViewControllerTest.java
+++ b/expensecalendar-backend/src/test/java/com/ozeken/expensecalendar/controller/CalendarViewControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.ozeken.expensecalendar.entity.AppUser;
@@ -21,6 +22,7 @@ import com.ozeken.expensecalendar.entity.LoginUser;
 import com.ozeken.expensecalendar.service.ExpenseService;
 
 @WebMvcTest(CalendarViewController.class)
+@ActiveProfiles("test")
 class CalendarViewControllerTest {
 
     @Autowired


### PR DESCRIPTION
- Spring Boot テスト用に `@ActiveProfiles("test")` を3クラスに再度追加 （単体テストではgradleの設定が効かないため）
- `findAllWithGenre` を使っていたテストを `findPagedExpensesByPage` に差し替え
- テストの可読性と安定性を改善