### PR TITLE
日付単位の支出一覧をページネーションで取得する機能を追加

### DIFF
--- a/expensecalendar-backend/src/main/java/com/ozeken/expensecalendar/controller/DayExpenseController.java
+++ b/expensecalendar-backend/src/main/java/com/ozeken/expensecalendar/controller/DayExpenseController.java
@@ -39,6 +39,8 @@ public class DayExpenseController{
      * @param year 年
      * @param month 月
      * @param day 日
+     * @param page ペース数
+     * @param size サイズ
      * @param loginUser ログインユーザー情報
      * @param model モデル
      * @return 詳細表示テンプレート
@@ -48,6 +50,8 @@ public class DayExpenseController{
     		@RequestParam int year,
     		@RequestParam int month,
     		@RequestParam int day,
+    		@RequestParam(name = "page", defaultValue = "1") int page,
+    		@RequestParam(name = "size", defaultValue = "20") int size,
     		@AuthenticationPrincipal LoginUser loginUser,
     		Model model) {
         if (loginUser.getAppUser() == null) {
@@ -55,12 +59,24 @@ public class DayExpenseController{
         }
 
         Long userId = loginUser.getAppUser().getId();
-        List<ExpenseWithGenre> expenses = expenseService.findWithGenreByDay(userId, year, month, day);
+        List<ExpenseWithGenre> expenses = expenseService.findPagedExpensesByDayAndPage(userId, year, month, day, page, size);
+        
+        // 1ページより大きいなら、減算する。
+        int prevPage = page > 1 ? page - 1 : 1;
+     		
+        // デフォルト値と同じなら、加算する。
+        boolean hasNext = expenses.size() == size;
+        int nextPage = hasNext ? page +1 : page;
 
         model.addAttribute("expenses", expenses);
         model.addAttribute("year", year);
         model.addAttribute("month", month);
         model.addAttribute("day", day);
+        model.addAttribute("currentPage", page);
+		model.addAttribute("pageSize", size);
+		model.addAttribute("prevPage", prevPage);
+		model.addAttribute("nextPage", nextPage);
+		model.addAttribute("hasNext", hasNext);
 
         return "expenses/day";
     }

--- a/expensecalendar-backend/src/main/java/com/ozeken/expensecalendar/mapper/ExpenseMapper.java
+++ b/expensecalendar-backend/src/main/java/com/ozeken/expensecalendar/mapper/ExpenseMapper.java
@@ -41,13 +41,18 @@ public interface ExpenseMapper {
      * @param year 年
      * @param month 月
      * @param day 日
+     * @param limit 取得する最大件数（1ページあたりの件数）
+     * @param offset 取得開始位置（例：0なら先頭から、10なら11件目から）
      * @return 支出リスト（ジャンル名付き）
      */
-    List<ExpenseWithGenre> selectWithGenreByUserIdAndDay(
+    List<ExpenseWithGenre> selectWithGenreByUserIdAndDayPaged(
         @Param("userId") Long userId,
         @Param("year") int year,
         @Param("month") int month,
-        @Param("day") int day);
+        @Param("day") int day,
+        @Param("limit") int limit,
+        @Param("offset") int offset
+        );
 
     
     // ------- 取得処理 (一件) ------------------------------------------------------

--- a/expensecalendar-backend/src/main/java/com/ozeken/expensecalendar/service/ExpenseService.java
+++ b/expensecalendar-backend/src/main/java/com/ozeken/expensecalendar/service/ExpenseService.java
@@ -37,17 +37,36 @@ public interface ExpenseService {
      */
     List<ExpenseWithGenre> findPagedExpensesByPage(Long userId, int page, int size);
     
+    
     /**
-	 * 指定ユーザーIDと年月日での支出リストを取得します（ジャンル名付き）
+	 * 指定ユーザーIDと年月日での支出一覧をページネーションで取得します（ジャンル名付き）
 	 *
 	 * @param userId ユーザーID
 	 * @param year 年
 	 * @param month 月
 	 * @param day 日
+	 * @param limit 取得する最大件数（1ページあたりの件数）
+	 * @param offset 取得開始位置（例：0なら先頭から、10なら11件目から）
 	 * @return 支出リスト（ジャンル名付き）
 	 */
-    List<ExpenseWithGenre> findWithGenreByDay(Long userId, int year, int month, int day);
+    List<ExpenseWithGenre> findPagedExpensesByDay(Long userId, int year, int month, int day, int limit, int offset);
+    
+    /**
+     * ページ番号とページサイズから支出一覧を取得（ページ番号は1から開始）
+     * 
+     * @param userId ユーザーID
+     * @param year 年
+	 * @param month 月
+	 * @param day 日
+     * @param page  現在のページ番号（1から始まる）
+     * @param size 1ページあたりの表示件数
+     * @return 支出リスト（ジャンル名付き、ページネーション対応）
+     * 
+     */
+    List<ExpenseWithGenre> findPagedExpensesByDayAndPage(Long userId, int year, int month, int day, int page, int size);
 
+    
+    
     // ------- 取得処理 (一件) ------------------------------------------
 
     /**

--- a/expensecalendar-backend/src/main/java/com/ozeken/expensecalendar/service/impl/ExpenseServiceImpl.java
+++ b/expensecalendar-backend/src/main/java/com/ozeken/expensecalendar/service/impl/ExpenseServiceImpl.java
@@ -36,7 +36,6 @@ public class ExpenseServiceImpl implements ExpenseService {
     
 	@Override
 	public List<ExpenseWithGenre> findPagedExpenses(Long userId, int limit, int offset) {
-		
 		return expenseMapper.selectWithGenreByUserIdPaged(userId, limit, offset);
 	}
 	
@@ -57,9 +56,28 @@ public class ExpenseServiceImpl implements ExpenseService {
 		return  findPagedExpenses(userId, size, offset);
 	}
     
+	// --------- 年月日別取得処理（リスト）------------------------------------
+	
     @Override
-	public List<ExpenseWithGenre> findWithGenreByDay(Long userId, int year, int month, int day) {
-		return expenseMapper.selectWithGenreByUserIdAndDay(userId, year, month, day);
+	public List<ExpenseWithGenre> findPagedExpensesByDay(Long userId, int year, int month, int day, int limit , int offset) {
+		return expenseMapper.selectWithGenreByUserIdAndDayPaged(userId, year, month, day, limit ,offset);
+	}
+    
+    /**
+	 * ページ番号とページサイズから支出一覧を取得（ページ番号は1から開始）
+	 */
+	@Override
+	public List<ExpenseWithGenre> findPagedExpensesByDayAndPage(Long userId, int year, int month, int day, int page, int size) {
+		
+		if (page < 1 ) {
+			page = 1;
+		}
+		if (size < 1 ) {
+			size = DEFAULT_PAGE_SIZE;
+		}
+		// 例: page=1 -> offset=0（先頭から取得）
+		int offset = (page-1) * size;
+		return  findPagedExpensesByDay(userId, year, month, day, size, offset);
 	}
     
     // ------- 取得処理 (一件) -----------------------------------------

--- a/expensecalendar-backend/src/main/resources/mapper/ExpenseMapper.xml
+++ b/expensecalendar-backend/src/main/resources/mapper/ExpenseMapper.xml
@@ -70,12 +70,14 @@
         WHERE e.id = #{id} AND e.user_id = #{userId}
         ORDER BY e.date DESC
     </select>
- 
-<!-- 
-  指定された年月日の日付における、全支出明細（ジャンル名付き）を取得するSQL。
-  主にカレンダーの詳細表示に使用される。
-  -->
-<select id="selectWithGenreByUserIdAndDay" resultMap="ExpenseWithGenreMap">
+    
+    <!-- 
+  指定された年月日、ユーザーIDに紐づく支出一覧を、ジャンル名付きでページネーション取得するSQL。
+  genresテーブルをJOINし、各支出に対応するジャンル名を取得する。
+  支出は日付の降順（新しい順）に並び、LIMIT/OFFSETで表示件数を制御する。
+  主に一覧画面（支出履歴ページ）での表示に使用される。
+-->
+<select id="selectWithGenreByUserIdAndDayPaged" resultMap="ExpenseWithGenreMap">
   SELECT 
     e.id,
     e.user_id,
@@ -90,8 +92,10 @@
     AND EXTRACT(YEAR FROM e.date) = #{year}
     AND EXTRACT(MONTH FROM e.date) = #{month}
     AND EXTRACT(DAY FROM e.date) = #{day}
-  ORDER BY e.date
+  ORDER BY e.date DESC
+  LIMIT #{limit} OFFSET #{offset}
 </select>
+    
 
 <!-- 
   指定されたユーザーIDに紐づく、全支出の合計金額を取得するSQL。

--- a/expensecalendar-backend/src/main/resources/templates/expenses/day.html
+++ b/expensecalendar-backend/src/main/resources/templates/expenses/day.html
@@ -11,7 +11,9 @@
     
     <div class="container">
 
-    <h1 th:text="${year} + '年' + ${month} + '月' + ${day} + '日の支出一覧'">yyyy年mm月dd日の支出一覧</h1>
+        <h1 th:text="|${year}年${month}月${day}日の支出一覧（ページ数：${currentPage}）|">
+            yyyy年mm月dd日の支出一覧
+        </h1>
     <br>
         <a th:href="@{/expenses/day/new(year=${year}, month=${month}, day=${day})}"  class="button register">新しい支出を登録する</a>
             <br>
@@ -56,6 +58,17 @@
             
         </tbody>
     </table>
+    
+    <!-- ページネーションリンク -->
+    <div>
+      <a th:href="@{/expenses/day?(year=${year}, month=${month}, day=${day},page=${prevPage}, size=${pageSize})}"
+         th:if="${currentPage > 1}">← 前へ</a>
+
+      <span>ページ <span th:text="${currentPage}">1</span></span>
+
+      <a th:href="@{/expenses/day?(year=${year}, month=${month}, day=${day}, page=${nextPage}, size=${pageSize})}"
+         th:if="${hasNext}">次へ →</a>
+    </div>
     
     <br>
     


### PR DESCRIPTION
## 概要

日付単位の支出一覧をページネーションで取得する機能を追加しました。

---

## 主な変更点

### xml, mapper クラス
- `selectWithGenreByUserIdAndDayPaged` メソッドを追加

### service クラス
- 旧メソッド `findWithGenreByDay` を削除し、新しいページネーション形式に統一
- Serviceインタフェースに `findPagedExpensesByDay` / `findPagedExpensesByDayAndPage` を追加
- 実装クラス `ExpenseServiceImpl` に対応する実装を追加

### controller / view
- `DayExpenseController` にページ番号・ページサイズの処理を追加
- テンプレート `day.html` にページネーションリンクを表示
- prev/next のページ情報をコントローラー側で計算して渡すことで、テンプレートの記述を簡潔に
